### PR TITLE
refactor: version information for enterprise css and js

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -17,8 +17,11 @@
     {{ end }}
 
     {{ if $.Site.Params.enterprise_enabled }}
-      <link data-test="{{$basePath}}" rel="stylesheet" href="{{ path.Join $basePath "/presidium-enterprise.css" }}">
-      <link data-test="{{$basePath}}" rel="preload" src="{{ path.Join $basePath "/presidium-enterprise.js" }}" as="script">
+      {{ $enterpriseScript := $.Site.Params.enterprise_script | default "/presidium-enterprise.js" }}
+      {{ $enterpriseStyling := $.Site.Params.enterprise_script | default "/presidium-enterprise.css" }}
+      
+      <link data-test="{{$basePath}}" rel="stylesheet" href="{{ path.Join $basePath $enterpriseStyling }}">
+      <link data-test="{{$basePath}}" rel="preload" href="{{ path.Join $basePath $enterpriseScript }}" as="script">
       <script data-test="{{$basePath}}"> window.baseURL = '{{$basePath}}'; </script>
     {{ end }}
 

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -18,7 +18,7 @@
 
     {{ if $.Site.Params.enterprise_enabled }}
       {{ $enterpriseScript := $.Site.Params.enterprise_script | default "/presidium-enterprise.js" }}
-      {{ $enterpriseStyling := $.Site.Params.enterprise_script | default "/presidium-enterprise.css" }}
+      {{ $enterpriseStyling := $.Site.Params.enterprise_styling | default "/presidium-enterprise.css" }}
       
       <link data-test="{{$basePath}}" rel="stylesheet" href="{{ path.Join $basePath $enterpriseStyling }}">
       <link data-test="{{$basePath}}" rel="preload" href="{{ path.Join $basePath $enterpriseScript }}" as="script">


### PR DESCRIPTION
## Description
- Use enterprise script and style from content builder
    - Have default fallback

## Issue
- [x] :clipboard: [PRSDM-6838](https://spandigital.atlassian.net/browse/PRSDM-6838)

## Screenshots

## PR Readiness Checks
- [x] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [x] You have performed a self-review of your changes via the GitHub UI
- [x] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [x] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
- [x] Changes were tested locally
