### PR TITLE
feat: move global footer option to list and single

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -20,6 +20,7 @@
 # Go workspace file
 go.work
 go.work.sum
+go.sum
 
 # env file
 .env

--- a/go.mod
+++ b/go.mod
@@ -1,3 +1,3 @@
-module github.com/spandigital/presidium-layouts-base
+module presidium-layouts-base
 
-go 1.23
+go 1.18

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -81,7 +81,6 @@
     </div>
     <div class="container-fluid">
       {{ block "globalfooter" . }}
-        {{/*  {{ partial "page/globalfooter" . }}  remove this comment to enable global footer */}}
       {{ end }}
     </div>
 

--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -1,6 +1,6 @@
 {{ define "header" }}
-{{ .Scratch.Set "scope" "list" }}
-{{ partial "page/header" . }}
+    {{ .Scratch.Set "scope" "list" }}
+    {{ partial "page/header" . }}
 {{ end }}
 
 {{ define "content" }}
@@ -8,5 +8,9 @@
 {{ end }}
 
 {{ define "footer" }}
-{{ partial "page/footer" . }}
+    {{ partial "page/footer" . }}
+{{ end }}
+
+{{ block "globalfooter" . }}
+    {{/*  {{ partial "page/globalfooter" . }}  remove this comment to enable global footer */}}
 {{ end }}

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -1,16 +1,20 @@
 {{ define "header" }}
-{{ .Scratch.Set "scope" "single" }}
-{{ partial "page/header" . }}
+    {{ .Scratch.Set "scope" "single" }}
+    {{ partial "page/header" . }}
 {{ end }}
 
 {{ define "content" }}
-{{ if eq $.Site.Params.archive.path .File.Path }}
-    {{ partial "common/archive" . }}
-{{ else }}
-    {{ partial "article/root" . }}
-{{ end }}
+    {{ if eq $.Site.Params.archive.path .File.Path }}
+        {{ partial "common/archive" . }}
+    {{ else }}
+        {{ partial "article/root" . }}
+    {{ end }}
 {{ end }}
 
 {{ define "footer" }}
-{{ partial "page/footer" . }}
+    {{ partial "page/footer" . }}
+{{ end }}
+
+{{ block "globalfooter" . }}
+    {{/*  {{ partial "page/globalfooter" . }}  remove this comment to enable global footer */}}
 {{ end }}


### PR DESCRIPTION
1. Testing `hugo mog get -u` import with no github domain in the go.mod module declaration
2. Moved Global footer partial call out of baseof.html and into list.html & single.html for easier overrides in the enterprise layer.