### PR TITLE
fix: PRSDM-5064 Add sorting by file path order in ascending/descending

### DIFF
--- a/layouts/partials/article/root.html
+++ b/layouts/partials/article/root.html
@@ -34,9 +34,14 @@
 
     {{ if $nestedArticles }}
         {{/* Sort by filename if specified in config */}}
-        {{ if .Site.Params.sortByFilePath }}
+        {{ $sortByFilePath := .Parent.Params.sortByFilePath | default .Site.Params.sortByFilePath }}
+        {{ if $sortByFilePath }}
+            {{ $sortOrder := "" }}
+            {{ if eq $sortByFilePath "desc" }}
+                {{ $sortOrder = "desc" }}
+            {{ end }}
             {{/* Sort by file prefix */}}
-            {{ range sort .Data.Pages "File.Path" }}
+            {{ range sort .Data.Pages "File.Path" $sortOrder }}
                 {{ partial "article/root" . }}
             {{ end }}
         {{ else }}

--- a/layouts/partials/navigation/nav-item.html
+++ b/layouts/partials/navigation/nav-item.html
@@ -61,8 +61,15 @@
     {{ if $hasChildren }}
         <ul id="{{$uid}}" class="collapse">
             {{ $pages := (partial "common/pages" .NavPage )}}
-            {{ if .NavPage.Site.Params.sortByFilePath }}
-                {{ range $index, $subMenu := (sort (after $offset $pages) "File.Path") }}
+            {{/* Sort by filename if specified in config */}}
+            {{ $sortByFilePath := .NavPage.Params.sortByFilePath | default .NavPage.Site.Params.sortByFilePath }}
+            {{ if $sortByFilePath }}
+                {{ $sortOrder := "" }}
+                {{ if eq $sortByFilePath "desc" }}
+                    {{ $sortOrder = "desc" }}
+                {{ end }}
+                {{/* Sort by file prefix */}}
+                {{ range $index, $subMenu := (sort (after $offset $pages) "File.Path" $sortOrder) }}
                     {{ partial "navigation/nav-item" (dict "NavPage" $subMenu "Level" $childLevel "Index" $index "RootUrl" $rootUrl "SlugifyUrl" $slugifyUrl ) }}
                 {{ end }}
             {{ else }}

--- a/layouts/partials/page/list.html
+++ b/layouts/partials/page/list.html
@@ -28,9 +28,14 @@
 {{ $siteScopesEnabled := .Site.Params.scopesEnabled }}
 
 {{/* Sort by filename if specified in config */}}
-{{ if .Site.Params.sortByFilePath }}
+{{ $sortByFilePath := .Params.sortByFilePath | default .Site.Params.sortByFilePath }}
+{{ if $sortByFilePath }}
+    {{ $sortOrder := "" }}
+    {{ if eq $sortByFilePath "desc" }}
+        {{ $sortOrder = "desc" }}
+    {{ end }}
     {{/* Sort by file prefix */}}
-    {{ range sort $pages "File.Path" }}
+    {{ range sort $pages "File.Path" $sortOrder }}
         {{ $isRendering := true }}
 
         {{ if $siteScopesEnabled }}


### PR DESCRIPTION
Introduced functionality to sort articles, navigation items, and pages by file path in both ascending and descending order based on configuration. Updated partial templates to respect `sortByFilePath` parameter, providing more flexibility in content presentation.

## Description

* Add sorting direction by file path.
* Allow sorting direction to be defined at path level by setting it in the frontmatter:

eg:
```
---
title: Updates
sortByFilePath: "desc"
---
```

## Issue
- [https://spandigital.atlassian.net/browse/PRSDM-5065](https://spandigital.atlassian.net/browse/PRSDM-5065)

## Screenshots


<img width="784" alt="image" src="https://github.com/user-attachments/assets/8fe002ac-6153-4d15-805d-c18a492cb5a3">


## PR Readiness Checks
- [ ] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [ ] You have performed a self-review of your changes via the GitHub UI
- [ ] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [ ] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
