### PR TITLE
fix: PRSDM-7037 data-section to return correct path.Dir instead of return /_index.md

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -69,7 +69,7 @@
           <div class="row">
               <div id="presidium-content">
                   {{ block "header" . }}{{ end }}
-                  <section data-section="{{ strings.TrimPrefix "/" .Path }}">
+                  <section data-section="{{ path.Dir .Path }}">
                     {{ block "content" . }}{{ end }}
                   </section>
               </div>


### PR DESCRIPTION
## Description

data-section includes the suffix "/_index.md", see ticket for details.

This PR reverts change to parse .Path as a path to resolve article bar skeleton loader not loading because it the API call with `/_index.md` returns an empty result.

## Issue
- [PRSDM-7037](https://spandigital.atlassian.net/browse/PRSDM-7037)

## Screenshots

Resolved:

<img width="394" alt="image" src="https://github.com/user-attachments/assets/6f33e179-8833-4818-8f69-41ea46bf8df8" />

<img width="269" alt="image" src="https://github.com/user-attachments/assets/3c4799d0-92b0-446f-b187-306b5da5f091" />


## PR Readiness Checks
- [ ] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [ ] You have performed a self-review of your changes via the GitHub UI
- [ ] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [ ] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
