### PR TITLE
feat: PRSM-6839 add snippet output format for standalone/embeddable articles

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,1 +1,3 @@
-COMING SOON . . . 
+## 2025-01-21
+### Feature
+- Add Snippet output for standalone articles in isolated contexts. @DustinFischer https://spandigital.atlassian.net/browse/PRSDM-7122

--- a/README.md
+++ b/README.md
@@ -1,3 +1,30 @@
 # presidium-layouts-base
 Base Hugo layouts for Presidium
 
+## Custom Output Formats
+
+### Snippets
+
+The `Snippet` output format is a alternative HTML output format to the standard output  (`index.html`) for _pages_ and _sections_. It's intended for generating standalone articles that can be used in third-party/isolated contexts (such as in an `iframe`).
+
+Features of a snippet:
+ - Generates content from the `content/` directory.
+ - Uses the same stylesheets as the standard output.
+ - Excludes inter-host navigation contexts that are in the standard output, such as the toolbar and left sidebar.
+ - Includes breadcrumbs to ancestor snippets for limited navigation within the docset.
+
+**Usage**  
+
+Snippet outputs must be configured per docset repository in `config.yml`.
+
+```yaml
+# <my-docset>/config.yml
+...
+outputs:
+  page:
+    - html      # -> index.html
+    - snippet   # -> snippet.html
+  section:
+    - html      # -> index.html
+    - snippet   # -> snippet.html
+```

--- a/config.yml
+++ b/config.yml
@@ -19,6 +19,11 @@ outputformats:
   Compendium:
     baseName: compendium
     mediaType: application/json
+  Snippet:
+    basename: snippet
+    mediaType: text/html
+    isHtml: true
+    permalinkable: true
 outputs:
   home:
     - Navigation

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -26,15 +26,18 @@
     {{ end }}
 
     {{ if $.Site.Params.lazyLoad }}
+    {{ block "scripts" . }}
       {{ $url := urls.Parse .Site.BaseURL }}
       {{ $url = path.Clean $url.Path }}
       {{ $navUrl := path.Join $url "/navigation.js"  }}
       <script src="{{$navUrl}}"></script>
     {{ end }}
+    {{ end }}
 </head>
 
 <body id="presidium" {{ partial "page/attributes" . }}>
     {{ if $.Site.Params.enterprise_enabled }}
+    {{ block "toolbar" . }}
       <div class="toolbar-wrapper">
         <button class="toggle">
           <span class="sr-only">Toggle navigation</span>
@@ -49,6 +52,7 @@
           class="presidium-enterprise"
         ></div>
       </div>
+    {{ end }}
     {{ end }}
 
     <div class="content-wrapper">
@@ -67,6 +71,7 @@
 
       <div id="presidium-container" class="container-fluid">
           <div class="row">
+            {{ block "breadcrumbs" .}}{{ end }}
               <div id="presidium-content">
                   {{ block "header" . }}{{ end }}
                   <section data-section="{{ strings.TrimPrefix "/" .Path }}">

--- a/layouts/_default/list.snippet.html
+++ b/layouts/_default/list.snippet.html
@@ -1,0 +1,25 @@
+{{ define "scripts" }}
+    {{ partial "common/dummy" . }}
+{{ end }}
+
+{{ define "toolbar" }}
+    {{ partial "common/dummy" . }}
+{{ end }}
+
+{{ define "left-sidebar" }}
+    {{ partial "common/dummy" . }}
+{{ end }}
+
+{{ define "breadcrumbs" }}
+    {{ .Scratch.Set "output-format" "snippet" }}
+    {{ partial "page/breadcrumbs" . }}
+{{ end }}
+
+{{ define "header" }}
+    {{ .Scratch.Set "scope" "list" }}
+    {{ partial "page/header" . }}
+{{ end }}
+
+{{ define "content" }}
+    {{ partial "page/list" . }}
+{{ end }}

--- a/layouts/_default/single.snippet.html
+++ b/layouts/_default/single.snippet.html
@@ -1,0 +1,25 @@
+{{ define "scripts" }}
+    {{ partial "common/dummy" . }}
+{{ end }}
+
+{{ define "toolbar" }}
+    {{ partial "common/dummy" . }}
+{{ end }}
+
+{{ define "left-sidebar" }}
+    {{ partial "common/dummy" . }}
+{{ end }}
+
+{{ define "breadcrumbs" }}
+    {{ .Scratch.Set "output-format" "snippet" }}
+    {{ partial "page/breadcrumbs" . }}
+{{ end }}
+
+{{ define "header" }}
+    {{ .Scratch.Set "scope" "single" }}
+    {{ partial "page/header" . }}
+{{ end }}
+
+{{ define "content" }}
+    {{ partial "article/root" . }}
+{{ end }}

--- a/layouts/partials/common/dummy.html
+++ b/layouts/partials/common/dummy.html
@@ -1,0 +1,1 @@
+{{/* a dummy template to force block overrides with no content */}}

--- a/layouts/partials/page/breadcrumbs.html
+++ b/layouts/partials/page/breadcrumbs.html
@@ -1,0 +1,14 @@
+{{- $outputFormat := $.Scratch.Get "output-format" -}}
+<div aria-label="breadcrumb" class="breadcrumb">
+    <li><a href="{{.Site.BaseURL}}"{{if $outputFormat}} target="_blank" rel="noopener"{{end}}>{{ .Site.Title }}</a></li>
+    {{- range $index, $ancestor := .Ancestors.Reverse -}}
+    {{ if $outputFormat -}}
+    {{ with $ancestor.OutputFormats.Get $outputFormat -}}
+    <li><a href="{{ $ancestor.RelPermalink }}">{{ $ancestor.LinkTitle }}</a></li>
+    {{- end }}
+    {{- end }}
+    {{ else }}
+    <li><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></li>
+    {{ end -}}
+    <li class="active">{{ .LinkTitle }}</li>
+</div>


### PR DESCRIPTION
## Issue
- [ ] :clipboard: [PRSDM-6839](https://spandigital.atlassian.net/browse/PRSDM-6839)

## Description

Adds a new `Snippet` output format:
   * The `Snippet` output format is an _alternative output format_ to the standard output format (`index.html`).  
   * Generates is a standalone HTML output that is a _stripped down version_ of a page/section. 
   * This is a separate `snippet.html` file per page/section, alongside the respective `index.html`.

Comp between `snippet.html` and `index.html`:
   * Renders the same basic content from the markown content files. 
   * Omits any peripheral contexts such as the toolbar and sidebar navigation.
   * Is styled according to the same styling rules as the standard output format.
   * The _toolbar_ and _left-nav menu_ are replaced  by  _breadcrumbs_ for basic navigability.
     * A breadcrumb links out to the respective `snippet.html` in the same window.

### Use cases

* The `Snippet` output format is intended to be used to present Presidium content in an isolated context where the full Presidium/enterprise feature set -- such as menu/navigation/toolbar etc. -- is not appropriate. 
* It should be used in scenarios where a Presidium user should only be able to access a restricted subset of Presidium resources.

A good example would be presenting Presidium articles from nested browsing contexts (such as in an iframe). In third-party contexts, the iframe should not load a fully navigable docset, as the user would be able to unintentionally navigate and access other Presidium resources the entire Presidium site, and not only the content you intended to show the user.
A good example of this is used in nested browsing contexts (such as in an `iframe`), but it could be used anywhere where you want a page to render with minimal navigability and peripheral context.

## Screenshots

**A snippet output:**
<img width="1552" alt="Screenshot 2025-01-14 at 16 55 29" src="https://github.com/user-attachments/assets/06fbb4f2-5163-4e10-b147-bafe1aab81e5" />

compared with its standard counterpart:
<img width="1552" alt="Screenshot 2025-01-14 at 16 57 22" src="https://github.com/user-attachments/assets/ab8e26a7-25f4-408e-8b88-f6feec53f17b" />

## Demo

https://github.com/user-attachments/assets/3596cf5e-bb6e-479c-957b-292395b2ac60

## PR Readiness Checks
- [x] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [ ] You have performed a self-review of your changes via the GitHub UI
- [ ] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [ ] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
