### PR TITLE
feat: PRSDM-7228 gh-actions auto release main

### DIFF
--- a/.github/workflows/lint-pr-title.yml
+++ b/.github/workflows/lint-pr-title.yml
@@ -1,0 +1,21 @@
+name: "Lint PR Title"
+
+on:
+  pull_request:
+    types:
+      - opened
+      - reopened
+      - edited
+      - synchronize
+permissions:
+  pull-requests: read
+  contents: read
+  packages: read
+jobs:
+  main:
+    name: Validate PR title
+    runs-on: ubuntu-latest
+    steps:
+      - uses: amannn/action-semantic-pull-request@v5
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,0 +1,18 @@
+name: release
+on:
+  push:
+    branches:
+      - main
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Checkout Code
+        uses: actions/checkout@v4
+        with:
+          persist-credentials: false # to disable default GITHUB_TOKEN
+      
+      - name: Semantic Release
+        uses: cycjimmy/semantic-release-action@v4
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,7 +1,8 @@
 {
   "branches": ["main", { "name": "develop", "prerelease": "rfv" }, "+([0-9])?(.{+([0-9]),x}).x"],
   "plugins": [
-    ["@semantic-release/commit-analyzer",
+    [
+      "@semantic-release/commit-analyzer",
       {
         "releaseRules": [
           {
@@ -10,8 +11,9 @@
           }
         ]
       }
-    ], 
-    ["@semantic-release/release-notes-generator",
+    ],
+    [
+      "@semantic-release/release-notes-generator",
       {
         "presetConfig": {
           "types": [
@@ -24,6 +26,11 @@
         }
       }
     ],
-    ["@semantic-release/github"]
+    [
+      "@semantic-release/github",
+      {
+        "successComment": false
+      }
+    ]
   ]
 }

--- a/.releaserc.json
+++ b/.releaserc.json
@@ -1,5 +1,5 @@
 {
-  "branches": ["main", { "name": "develop", "prerelease": "rfv" }, "+([0-9])?(.{+([0-9]),x}).x"],
+  "branches": ["main", "+([0-9])?(.{+([0-9]),x}).x"],
   "plugins": [
     [
       "@semantic-release/commit-analyzer",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,3 +1,10 @@
 ## 2025-01-21
 ### Feature
 - Add Snippet output for standalone articles in isolated contexts. @DustinFischer https://spandigital.atlassian.net/browse/PRSDM-7122
+
+## 2025-01-23
+### Feature
+- github action to auto generate semantic release for main.
+- added pr title linting from https://github.com/SPANDigital/presidium-theme-website/commit/e940f801c5d29bcc479c3f6cc17b5b95ac2ef30d
+- updated readme
+@Quantumplate [PRSDM-7228](https://spandigital.atlassian.net/browse/PRSDM-7228)

--- a/README.md
+++ b/README.md
@@ -9,7 +9,7 @@ Update the `config.yml`:
 ```
 module:
   imports:
-  - path: github.com/SPANDigital/presidium-styling-base
+  - path: github.com/spandigital/presidium-styling-base
   - path: github.com/spandigital/presidium-layouts-base
 ```
 
@@ -19,7 +19,7 @@ module:
 1. Open the `go.mod` file in your `presidium-test-validation` clone.
 1. Add the following to the bottom of your `go.mod` file, and update the path after the arrow to the correct path where you cloned the theme layout:
 ```
-replace github.pie.apple.com/ase-docs/presidium-layouts-base => /{path-on-your-machine}/presidium-layouts-base
+replace github.com/spandigital/presidium-layouts-base => /{path-on-your-machine}/presidium-layouts-base
 ```
 
 4. Run a refresh and then build the docset with Hugo:

--- a/README.md
+++ b/README.md
@@ -1,6 +1,74 @@
 # presidium-layouts-base
 Base Hugo layouts for Presidium
 
+This is part of default Hugo theme for Presidium sites.  
+For more info on Hugo Themes see the official Hugo documentation [here](https://gohugo.io/hugo-modules/theme-components/) 
+
+# Getting Started
+
+### Method 1 - Just using the Presidium Themes in your Hugo site (Default)
+Update the `config.yml`:
+```
+module:
+  imports:
+  - path: github.com/SPANDigital/presidium-styling-base
+  - path: github.com/spandigital/presidium-layouts-base
+```
+
+### Method 2 - Working on contributing to this repo in local development.
+1. Clone the theme
+1. Clone the [presidium-test-validation](https://github.com/SPANDigital/presidium-test-validation) repo. We use the `presidium-test-validation` repo as the styling and functionality test bed, where we throw all the officially supported features in with the kitchen sink, so that we can validate every theme change has no unintended effects.
+1. Open the `go.mod` file in your `presidium-test-validation` clone.
+1. Add the following to the bottom of your `go.mod` file, and update the path after the arrow to the correct path where you cloned the theme layout:
+```
+replace github.pie.apple.com/ase-docs/presidium-layouts-base => /{path-on-your-machine}/presidium-layouts-base
+```
+
+4. Run a refresh and then build the docset with Hugo:
+```
+make refresh
+```
+If you don't have the Makefile in your docset, then you can copy it from [here](https://github.com/SPANDigital/presidium/blob/develop/templates/default/Makefile)
+Then run
+```
+make serve
+```
+Your served site should be available on `localhost:1313`.
+
+---
+
+## Conventional Commits
+
+At SPAN we use [Conventional Commits 1.0.0](https://www.conventionalcommits.org/en/v1.0.0/) to make our commit messages more useful.
+
+## Semantic Releases
+
+This repository uses [Semantic Release](https://semantic-release.gitbook.io/semantic-release/) tool to automate version management and package publishing.
+
+Upon merging into to the main or develop branch, Semantic Release tool will:
+- Calculate the new release version based on the commits
+- Create a git commit and a git tag for the release
+- Create a Release with release notes from the commit messages
+- Create and publish the container images
+
+---
+
+## Branching
+
+Please see this [Presidium Git Strategy Miro board](https://miro.com/app/board/uXjVPK0XxiU=/).
+
+In summary:
+- `main` ⇾ production
+  - Only hotfixes or `develop` get merged into `main`
+- `develop`
+  - Feature branches and bug fixes are branched from and merged into `develop`
+- `feat/<TITLE>`
+  - If there is a feature in development it will be on a feature branch
+
+---
+
+# Advanced Configuration
+
 ## Custom Output Formats
 
 ### Snippets

--- a/README.md
+++ b/README.md
@@ -1,7 +1,5 @@
 # presidium-layouts-base
-Base Hugo layouts for Presidium
-
-This is part of default Hugo theme for Presidium sites.  
+This repo makes up the `layouts` portion of the Presidium System Level Theme, and contains the officially support theme features.
 For more info on Hugo Themes see the official Hugo documentation [here](https://gohugo.io/hugo-modules/theme-components/) 
 
 # Getting Started


### PR DESCRIPTION
## Description
Adding gh-action to auto generate semantic release for main

## Issue
- [x] :clipboard: [PRSDM-7228](https://spandigital.atlassian.net/browse/PRSDM-7228)

## Screenshots

## PR Readiness Checks
- [x] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [x] You have performed a self-review of your changes via the GitHub UI
- [x] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [x] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
