### PR TITLE
fix: PRSDM-7027-Add a mechanism for handling missing sections in module config file

### DIFF
--- a/layouts/partials/searchmap/root.html
+++ b/layouts/partials/searchmap/root.html
@@ -1,12 +1,9 @@
 {{ $items := slice }}
-{{ $roles := slice }}
-{{ $urilzeIdentifier := slice }}
-{{ range $menu := .Site.Menus.main.ByWeight }}
-    {{ $urilzeIdentifier = $menu.Identifier | urlize  }}
-    {{ with $.Site.GetPage "section" $urilzeIdentifier }}
-        {{ range $searchmapItem := (partial "searchmap/item" (dict "Page" . "Level" 1) )}}
-            {{ $items = $items | append $searchmapItem }}
-        {{ end }}
+
+{{ range (union .Site.RegularPages .Site.Sections) }}
+    {{ range $searchmapItem := (partial "searchmap/item" (dict "Page" . "Level" 1)) }}
+        {{ $items = $items | append $searchmapItem }}
     {{ end }}
 {{ end }}
+
 {{ return $items }}


### PR DESCRIPTION
## Description
Previously, `searchmap.json` only included pages defined in `menu.main` (from the `config.yml` file), as `partials/searchmap/root.html` looped over `.Site.Menus.main.ByWeight`. This excluded content that existed in the `content/` folder but wasn't explicitly listed in `menu.main`, therefore these articles were not stored.

### Solution
The fix replaces `.Site.Menus.main.ByWeight` with `union .Site.RegularPages .Site.Sections`, ensuring all pages—both standalone articles and `_index.md` file from sections not included in the `config.yml` file are indexed in `searchmap.json` sent to the API this way the `ArticleBar` component from `presidium-enterprise-js` is able to show by loading these articles.

## Issue
[PRSDM-7027](https://spandigital.atlassian.net/browse/PRSDM-7027)

## Screenshots
https://github.com/user-attachments/assets/a13bdd98-29a8-4620-966a-4bc26a3898fd


## PR Readiness Checks
- [x] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [x] You have performed a self-review of your changes via the GitHub UI
- [ ] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [x] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
