### PR TITLE
fix: PRSDM-7219 / Presidium Feedback Bar Fails With Uppercase Directory Names

### DIFF
--- a/layouts/partials/article/root.html
+++ b/layouts/partials/article/root.html
@@ -12,7 +12,7 @@
 {{/* Unique id for this article */}}
 {{ $file := .File }}
 {{ if $file}}
-{{ $articleId := .Params.id | default $file.Path }}
+{{ $articleId := lower (.Params.id | default $file.Path) }}
 {{ $noContent := (eq (len .Content) 0) }}
 
 {{/* Unique id for file, used by scroll-spy and menu toggle  */}}

--- a/layouts/partials/page/list.html
+++ b/layouts/partials/page/list.html
@@ -1,10 +1,10 @@
 {{ $roles := .Params.roles | default "All Roles" }}
 {{ $uid := "" }}
-{{ $articleId := .Params.id }}
+{{ $articleId := lower .Params.id }}
 {{ with .File }}
     {{ $uid = .UniqueID }}
     {{ if not $articleId }}
-        {{ $articleId = .Path }}
+        {{ $articleId = lower .Path }}
     {{ end }}
 {{ end }}
 {{ $pageLink := .Page.RelPermalink }}

--- a/layouts/partials/searchmap/item.html
+++ b/layouts/partials/searchmap/item.html
@@ -29,7 +29,7 @@
     {{ end }}
     {{ $tags := apply .Params.tags "cast.ToString" "."}}
     {{ $summary := (index (split .Content "</p>") 0) | plainify | htmlUnescape }}
-    {{ $items = $items | append (dict "id" .File.Path "title" .Title "slug" $slug "url" $link "section" ($section | default "") "category" ($category | default "") "tags" ($tags | default slice) "roles" (slice (.Params.Roles | default "All Roles")) "scope" $scope "author" (.Params.Author | default "None") "content" .Plain "originalContent" .RawContent "updated" .Lastmod "summary" $summary  )}}
+    {{ $items = $items | append (dict "id" (lower .File.Path) "title" .Title "slug" $slug "url" $link "section" ($section | default "") "category" ($category | default "") "tags" ($tags | default slice) "roles" (slice (.Params.Roles | default "All Roles")) "scope" $scope "author" (.Params.Author | default "None") "content" .Plain "originalContent" .RawContent "updated" .Lastmod "summary" $summary  )}}
     {{ range .Data.Pages }}
         {{ range (partial "searchmap/item" (dict "Page" . "Level" $childLevel "Section" $section "Category" $category ) ) }}
           {{ $items = $items | append . }}


### PR DESCRIPTION
## Description

## Issue
- [ ] :clipboard: JIRA_TICKET_URL

## Screenshots

## PR Readiness Checks
- [ ] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [ ] You have performed a self-review of your changes via the GitHub UI
- [ ] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [ ] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
