### PR TITLE
refactor: PRSDM-7402 disable clickable breadcrumb items snippet output

### DIFF
--- a/layouts/partials/page/breadcrumbs.html
+++ b/layouts/partials/page/breadcrumbs.html
@@ -1,14 +1,12 @@
 {{- $outputFormat := $.Scratch.Get "output-format" -}}
 <div aria-label="breadcrumb" class="breadcrumb">
-    <li><a href="{{.Site.BaseURL}}"{{if $outputFormat}} target="_blank" rel="noopener"{{end}}>{{ .Site.Title }}</a></li>
+    <li class="breadcrumb-item"><span class="site-title">{{ .Site.Title }}</span></li>
     {{- range $index, $ancestor := .Ancestors.Reverse -}}
     {{ if $outputFormat -}}
     {{ with $ancestor.OutputFormats.Get $outputFormat -}}
-    <li><a href="{{ $ancestor.RelPermalink }}">{{ $ancestor.LinkTitle }}</a></li>
+    <li class="breadcrumb-item"><span class="ancestor-title">{{ $ancestor.LinkTitle }}</span></li>
     {{- end }}
     {{- end }}
-    {{ else }}
-    <li><a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a></li>
     {{ end -}}
-    <li class="active">{{ .LinkTitle }}</li>
+    <li class="breadcrumb-item active"><span class="page-title">{{ .LinkTitle }}</li>
 </div>


### PR DESCRIPTION
## Description
Removes clickability of breadcrumb items in embed/snippet outputs. 
There's no good way to navigate back once an iframe has navigated in-frame, making clickable breadcrumbs unsuitable.

## Issue
- [ ] :clipboard: [PRSDM-7402](https://spandigital.atlassian.net/browse/PRSDM-7402)

## Screenshots

## PR Readiness Checks
- [x] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [x] You have performed a self-review of your changes via the GitHub UI
- [ ] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [ ] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
