### PR TITLE
refactor: PRSDM-7375 rename Snippet output format to Embed

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -28,8 +28,6 @@ outputs:
   home:
     - Navigation
     - Compendium
-cascade:
- type: 
 params:
   _merge: shallow
   attributes:

--- a/config.yml
+++ b/config.yml
@@ -19,8 +19,8 @@ outputformats:
   Compendium:
     baseName: compendium
     mediaType: application/json
-  Snippet:
-    basename: snippet
+  Embed:
+    basename: embed
     mediaType: text/html
     isHtml: true
     permalinkable: true
@@ -28,6 +28,8 @@ outputs:
   home:
     - Navigation
     - Compendium
+cascade:
+ type: 
 params:
   _merge: shallow
   attributes:

--- a/layouts/_default/list.embed.html
+++ b/layouts/_default/list.embed.html
@@ -11,15 +11,14 @@
 {{ end }}
 
 {{ define "breadcrumbs" }}
-    {{ .Scratch.Set "output-format" "snippet" }}
-    {{ partial "page/breadcrumbs" . }}
+    {{ partial "page/embed/breadcrumbs" . }}
 {{ end }}
 
 {{ define "header" }}
-    {{ .Scratch.Set "scope" "single" }}
+    {{ .Scratch.Set "scope" "list" }}
     {{ partial "page/header" . }}
 {{ end }}
 
 {{ define "content" }}
-    {{ partial "article/root" . }}
+    {{ partial "page/list" . }}
 {{ end }}

--- a/layouts/_default/single.embed.html
+++ b/layouts/_default/single.embed.html
@@ -11,15 +11,14 @@
 {{ end }}
 
 {{ define "breadcrumbs" }}
-    {{ .Scratch.Set "output-format" "snippet" }}
-    {{ partial "page/breadcrumbs" . }}
+    {{ partial "page/embed/breadcrumbs" . }}
 {{ end }}
 
 {{ define "header" }}
-    {{ .Scratch.Set "scope" "list" }}
+    {{ .Scratch.Set "scope" "single" }}
     {{ partial "page/header" . }}
 {{ end }}
 
 {{ define "content" }}
-    {{ partial "page/list" . }}
+    {{ partial "article/root" . }}
 {{ end }}

--- a/layouts/partials/page/embed/breadcrumbs.html
+++ b/layouts/partials/page/embed/breadcrumbs.html
@@ -1,12 +1,6 @@
-{{- $outputFormat := $.Scratch.Get "output-format" -}}
 <div aria-label="breadcrumb" class="breadcrumb">
-    <li class="breadcrumb-item"><span class="site-title">{{ .Site.Title }}</span></li>
     {{- range $index, $ancestor := .Ancestors.Reverse -}}
-    {{ if $outputFormat -}}
-    {{ with $ancestor.OutputFormats.Get $outputFormat -}}
     <li class="breadcrumb-item"><span class="ancestor-title">{{ $ancestor.LinkTitle }}</span></li>
     {{- end }}
-    {{- end }}
-    {{ end -}}
     <li class="breadcrumb-item active"><span class="page-title">{{ .LinkTitle }}</li>
 </div>


### PR DESCRIPTION
## Description
Semantic renaming of `Snippet` to `Embed`.
* Moved breadcrumbs output format specific `embed` subfolder. 

## Issue
- [ ] :clipboard: [PRSDM-7375](https://spandigital.atlassian.net/browse/PRSDM-7375)

## Screenshots

## PR Readiness Checks
- [x] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [x] You have performed a self-review of your changes via the GitHub UI
- [ ] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [ ] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
