### PR TITLE
refactor: PRSDM-7806 temporarily support both snippet and embed output formats

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -24,6 +24,12 @@ outputformats:
     mediaType: text/html
     isHtml: true
     permalinkable: true
+  # TODO(PRSDM-7807): remove Snippet and related snippet templates once the API rework to serve embed.html instead of snippet.html is in SPAN production
+  Snippet:
+    basename: snippet
+    mediaType: text/html
+    isHtml: true
+    permalinkable: true
 outputs:
   home:
     - Navigation

--- a/layouts/_default/list.snippet.html
+++ b/layouts/_default/list.snippet.html
@@ -1,0 +1,24 @@
+{{ define "scripts" }}
+    {{ partial "common/dummy" . }}
+{{ end }}
+
+{{ define "toolbar" }}
+    {{ partial "common/dummy" . }}
+{{ end }}
+
+{{ define "left-sidebar" }}
+    {{ partial "common/dummy" . }}
+{{ end }}
+
+{{ define "breadcrumbs" }}
+    {{ partial "page/embed/breadcrumbs" . }}
+{{ end }}
+
+{{ define "header" }}
+    {{ .Scratch.Set "scope" "list" }}
+    {{ partial "page/header" . }}
+{{ end }}
+
+{{ define "content" }}
+    {{ partial "page/list" . }}
+{{ end }}

--- a/layouts/_default/single.snippet.html
+++ b/layouts/_default/single.snippet.html
@@ -1,0 +1,24 @@
+{{ define "scripts" }}
+    {{ partial "common/dummy" . }}
+{{ end }}
+
+{{ define "toolbar" }}
+    {{ partial "common/dummy" . }}
+{{ end }}
+
+{{ define "left-sidebar" }}
+    {{ partial "common/dummy" . }}
+{{ end }}
+
+{{ define "breadcrumbs" }}
+    {{ partial "page/embed/breadcrumbs" . }}
+{{ end }}
+
+{{ define "header" }}
+    {{ .Scratch.Set "scope" "single" }}
+    {{ partial "page/header" . }}
+{{ end }}
+
+{{ define "content" }}
+    {{ partial "article/root" . }}
+{{ end }}


### PR DESCRIPTION
## Description
Temporarily adds `Snippet` output format back to support backwards compatiblity until the `snippet` to `embed` rename changes are in SPAN Production.

## Issue
- [ ] :clipboard: [PRSDM-7806](https://spandigital.atlassian.net/browse/PRSDM-7806)

## Screenshots

## PR Readiness Checks
- [ ] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [ ] You have performed a self-review of your changes via the GitHub UI
- [ ] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [ ] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
