### PR TITLE
fix: updates to allow react to run with embeds

### DIFF
--- a/layouts/_default/list.embed.html
+++ b/layouts/_default/list.embed.html
@@ -20,5 +20,12 @@
 {{ end }}
 
 {{ define "content" }}
+    <div
+      data-key="{{ $.Site.Params.enterprise_key }}"
+      data-title="{{ $.Site.Title }}"
+      id="presidium-enterprise"
+      class="presidium-enterprise"
+      style="display: none"
+    ></div>
     {{ partial "page/list" . }}
 {{ end }}

--- a/layouts/_default/single.embed.html
+++ b/layouts/_default/single.embed.html
@@ -20,5 +20,12 @@
 {{ end }}
 
 {{ define "content" }}
+    <div
+      data-key="{{ $.Site.Params.enterprise_key }}"
+      data-title="{{ $.Site.Title }}"
+      id="presidium-enterprise"
+      class="presidium-enterprise"
+      style="display: none"
+    ></div>
     {{ partial "article/root" . }}
 {{ end }}

--- a/layouts/partials/page/embed/breadcrumbs.html
+++ b/layouts/partials/page/embed/breadcrumbs.html
@@ -2,5 +2,5 @@
     {{- range $index, $ancestor := .Ancestors.Reverse -}}
     <li class="breadcrumb-item"><span class="ancestor-title">{{ $ancestor.LinkTitle }}</span></li>
     {{- end }}
-    <li class="breadcrumb-item active"><span class="page-title">{{ .LinkTitle }}</li>
+    <li class="breadcrumb-item active"><span>{{ .LinkTitle }}</li>
 </div>


### PR DESCRIPTION
## Description
Adds required elements to allow react to run which enables the feedback bar, comments and other event tracking.
The added div has `display: none` to hide the enterprise top nav.


## Issue
- [x] :clipboard:[PRSDM-7583](https://spandigital.atlassian.net/browse/PRSDM-7583)

## Screenshots
![image](https://github.com/user-attachments/assets/3c313767-d021-416b-917a-a8d06f6f5680)

## PR Readiness Checks
- [ ] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [ ] You have performed a self-review of your changes via the GitHub UI
- [ ] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [ ] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
