### PR TITLE
fix: PRSDM-7854 explicitly initialize all mermaid diagrams

### DIFF
--- a/layouts/partials/page/script.html
+++ b/layouts/partials/page/script.html
@@ -111,15 +111,19 @@
   window.presidium?.tooltips?.load();
   window.presidium?.modal?.init();
 
-  mermaid.initialize({
-      startOnLoad: true,
-      theme: 'base',
-      themeVariables: {
-          'primaryColor': '#00827E',
-          'primaryBorderColor': '#2C6764',
-          'secondaryColor': '#FFFFFF',
-          'lineColor': '#666',
-      },
+  document.addEventListener('DOMContentLoaded', () => {
+    mermaid.initialize({
+        startOnLoad: true,
+        theme: 'base',
+        themeVariables: {
+            'primaryColor': '#00827E',
+            'primaryBorderColor': '#2C6764',
+            'secondaryColor': '#FFFFFF',
+            'lineColor': '#666',
+        },
+    });
+    // Explicitly initialize all Mermaid diagrams
+    mermaid.init(undefined, document.querySelectorAll('.mermaid'));
   });
 
   // Ensure nav-items fit within the viewport without overlapping the header

--- a/presidium-layouts-base
+++ b/presidium-layouts-base
@@ -1,0 +1,1 @@
+/Users/damianhunter/Documents/work/presidium/projects/presidium-layouts-base


### PR DESCRIPTION
Explicitly initialize all Mermaid diagrams once the DOM has finished loading

This was only an issue when served from a subpath and only related to the first diagram on a page.

## Issue
- [x] :clipboard: [PRSDM-7854](https://spandigital.atlassian.net/browse/PRSDM-7854)

## Screenshots

## PR Readiness Checks
- [x] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [x] You have performed a self-review of your changes via the GitHub UI
- [x] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [x] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
