### PR TITLE
fix: PRSDM-7956 incorrect section data for single embeds

### DIFF
--- a/layouts/_default/single.embed.html
+++ b/layouts/_default/single.embed.html
@@ -19,13 +19,17 @@
     {{ partial "page/header" . }}
 {{ end }}
 
-{{ define "content" }}
-    <div
-      data-key="{{ $.Site.Params.enterprise_key }}"
-      data-title="{{ $.Site.Title }}"
-      id="presidium-enterprise"
-      class="presidium-enterprise"
-      style="display: none"
-    ></div>
-    {{ partial "article/root" . }}
+{{ define "section" }}
+    <section data-section="{{ strings.TrimPrefix "/" .Parent.Path }}">
+        {{ block "content" . }}
+            <div
+              data-key="{{ $.Site.Params.enterprise_key }}"
+              data-title="{{ $.Site.Title }}"
+              id="presidium-enterprise"
+              class="presidium-enterprise"
+              style="display: none"
+            ></div>
+            {{ partial "article/root" . }}
+        {{ end }}
+    </section>
 {{ end }}


### PR DESCRIPTION
## Description

The section data for single embeds are incorrect causing pages to not load properly

## Issue
- [x] :clipboard: https://spandigital.atlassian.net/browse/PRSDM-7956

## Screenshots

## PR Readiness Checks
- [ ] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [ ] You have performed a self-review of your changes via the GitHub UI
- [ ] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [ ] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
