### PR TITLE
chore: PRSDM-7843 - Migrate latest changes from pdf-theme

### DIFF
--- a/layouts/partials/pdf/article.html
+++ b/layouts/partials/pdf/article.html
@@ -12,16 +12,10 @@
 {{ $path = replace $path $permalinkSlug $slug }}
 {{ end }}
 
-{{ $fileSlug := anchorize .context.File.BaseFileName }}
-{{ $fileSlugAlt := replaceRE `^\d+-` "" .context.File.BaseFileName }}
-{{ if eq .context.File.BaseFileName "_index" }}
-{{ $fileSlug = (partial "pdf/common/parent-slug" .context) }}
-{{ $fileSlugAlt = replaceRE `^\d+-` "" $fileSlug }}
-{{ end }}
-
 <div class="presidium-article-wrapper">
   {{ if ne .context.Parent.Title .context.Title}}
-  <h{{ $depth }} class="article-title" id="{{ $slug }}">{{ .context.Title }}</h{{ $depth }}>
+    <span id="{{ $slug }}"></span>
+    <h{{ $depth }} class="article-title" id="{{ $path }}">{{ .context.Title }}</h{{ $depth }}>
   {{ end }}
   {{ .context.Content }}
 </div>

--- a/static/links.js
+++ b/static/links.js
@@ -22,24 +22,28 @@ for (var i = 0; i < links.length; i++) {
     continue;
   }
 
-  href = href.replace(baseURL, "");
-
-  if (href.indexOf("#") === 0) {
-    continue;
-  }
+  // Normalize the URL by removing trailing slash before hash
+  href = href.replace(baseURL, "").replace(/\/(?=#)/, "");
 
   var segments = href.split("/").filter(function(x) {
     return x;
   });
 
-  var anchor = segments.pop();
+  // slugify the segments by replacing slashes and hashes with dashes
+  var newAnchor = segments.map(function(x) {
+    return x.replace("/", "-").replace("#", "-");
+  }).join("-");
 
-  if (anchor.indexOf("#") === 0) {
-    anchor = anchor.substring(1);
-  }
+  var match = document.getElementById(newAnchor);
 
-  var match = document.getElementById(anchor);
+  // If the article exists, link to it instead of the original URL
   if (match) {
-    link.href = "#" + anchor;
+    link.href = "#" + newAnchor;
+  }
+  else {
+    // If the article doesn't exist, link to the link hash instead
+    if (!link.hash == "") {
+      link.href = link.hash
+    }
   }
 }


### PR DESCRIPTION
## Description

Moved the latest fixes/changes from pdf-theme to layouts-base

## Issue
- [ ] :clipboard: [PRSDM-7843](https://spandigital.atlassian.net/browse/PRSDM-7843)

## Screenshots

## PR Readiness Checks
- [x] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [x] You have performed a self-review of your changes via the GitHub UI
- [ ] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [x] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
