### PR TITLE
feat: PRSDM-6345 - Add accessibility attributes (title, aria-label) to article tag

### DIFF
--- a/layouts/partials/article/content.html
+++ b/layouts/partials/article/content.html
@@ -1,2 +1,2 @@
 
-<article>{{ .Content }}</article>
+<article title="{{ .Title }}" aria-label="{{ .Title }}">{{ .Content }}</article>

--- a/layouts/partials/page/list.html
+++ b/layouts/partials/page/list.html
@@ -16,7 +16,7 @@
     <div class="presidium-article-wrapper">
         <span class="anchor" id="{{ $slug }}" data-id="{{ $articleId }}"></span>
         {{ if (ne (len .Content) 0) -}}
-            <article class="article-actions" data-align="center-top">{{ .Content }}</article>
+            <article class="article-actions" data-align="center-top" title="{{ .Title }}" aria-label="{{ .Title }}">{{ .Content }}</article>
             <hr />
         {{- end }}
     </div>


### PR DESCRIPTION
## Description
When migrating from `presidium-theme-website` to `presidium-layouts-base`, the `title` and `aria-label` attributes on the `<article>` element were not carried over. This PR reintroduces those attributes to maintain accessibility support as previously implemented for [PRSDM-6345](https://spandigital.atlassian.net/browse/PRSDM-6345), see related [commit](https://github.pie.apple.com/ase-docs/presidium-theme-website/commit/3053a211b7b0b3da4e27249407b7a67dd32576ff).

## Issue
- [PRSDM-6345](https://spandigital.atlassian.net/browse/PRSDM-6345)

## PR Readiness Checks
- [x] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [x] You have performed a self-review of your changes via the GitHub UI
- [ ] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [x] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
