### PR TITLE
fix: skip pages without .File to prevent build failure

### DIFF
--- a/layouts/partials/searchmap/item.html
+++ b/layouts/partials/searchmap/item.html
@@ -11,6 +11,7 @@
 {{ end }}
 
 {{ with .Page}}
+    {{ if .File }}
     {{ $slug := humanize .Params.Title }}
     {{ $slug = anchorize $slug }}
     {{ $slug = replaceRE `(-{2,})` "-" $slug }} {{/* Replaces multiple dashes with one */}}
@@ -30,6 +31,9 @@
     {{ $tags := apply .Params.tags "cast.ToString" "."}}
     {{ $summary := (index (split .Content "</p>") 0) | plainify | htmlUnescape }}
     {{ $items = $items | append (dict "id" .File.Path "title" .Title "slug" $slug "url" $link "section" ($section | default "") "category" ($category | default "") "tags" ($tags | default slice) "roles" (slice (.Params.Roles | default "All Roles")) "scope" $scope "author" (.Params.Author | default "None") "content" .Plain "originalContent" .RawContent "updated" .Lastmod "summary" $summary  )}}
+    {{ else }}
+    {{ warnf "[searchmap] Skipping page with nil .File: Title=%q, Permalink=%q" .Title .Permalink }}
+    {{ end }}
     {{ range .Data.Pages }}
         {{ range (partial "searchmap/item" (dict "Page" . "Level" $childLevel "Section" $section "Category" $category ) ) }}
           {{ $items = $items | append . }}


### PR DESCRIPTION
## Description
Fixes a Hugo build failure caused by attempting to access `.File.Path` on section pages without an `_index.md` file. These pages are automatically generated but don't have a backing file, so `.File` is `nil`.

### Root Cause
In `partials/searchmap/item.html`, the template attempted to access `.File.Path` unconditionally. This works for regular pages and sections with `_index.md`, but fails on those without `_index.md`.

## PR Readiness Checks
- [ ] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [x] You have performed a self-review of your changes via the GitHub UI
- [ ] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [x] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
