### PR TITLE
fix: PRSDM-8713-Moving to presidium container div

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -68,10 +68,10 @@
       <div id="resizer"></div>
       {{ end }}
 
-      <div id="presidium-container" class="container-fluid">
+      <div id="presidium-container" class="container-fluid {{ partial "type/typeclass" . }}">
         <div class="row">
           {{ block "breadcrumbs" .}}{{ end }}
-            <div id="presidium-content" class="{{ partial "type/typeclass"  }}">
+            <div id="presidium-content">
                 {{ block "header" . }}{{ end }}
                 {{ block "section" . }}
                 <section data-section="{{ strings.TrimPrefix "/" .Path }}">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -54,7 +54,7 @@
     {{ end }}
     {{ end }}
 
-    <div class="content-wrapper">
+    <div class="content-wrapper {{ partial "type/typeclass" . }}">
       {{ block "left-sidebar" . }}
       <div id="presidium-navigation">
         {{ if $.Site.Params.lazyLoad }}
@@ -68,7 +68,7 @@
       <div id="resizer"></div>
       {{ end }}
 
-      <div id="presidium-container" class="container-fluid {{ partial "type/typeclass" . }}">
+      <div id="presidium-container" class="container-fluid">
         <div class="row">
           {{ block "breadcrumbs" .}}{{ end }}
             <div id="presidium-content">


### PR DESCRIPTION
## Description

Moving type-class partial to out div

## Issue
- [x] https://spandigital.atlassian.net/browse/PRSDM-8713

## Screenshots

[
<img width="726" height="262" alt="Screenshot 2025-07-17 at 12 48 19" src="https://github.com/user-attachments/assets/391bd6f9-2f0f-423b-8065-c08ee6d1d14d" />
](url)

## PR Readiness Checks
- [x] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [x] You have performed a self-review of your changes via the GitHub UI
- [ ] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [x] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
