### PR TITLE
feat: PRSDM-8658 add Hugo version compatiblity check on build

### DIFF
--- a/config.yml
+++ b/config.yml
@@ -35,6 +35,11 @@ outputs:
     - Pdf
 params:
   _merge: shallow
+  hugoVersion:
+    enabled: true
+    min: "0.133.0"
+    max: "0.147.7"
+    extended: true
   attributes:
     website: 2.15.0
   frontmatter:

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -3,6 +3,9 @@
 <head>
     <meta charset="utf-8">
     <title>{{ if .IsHome }}{{ $.Site.Title }}{{ else }}{{ .Title }} - {{ .Site.Title }}{{ end }}</title>
+    
+    {{/* Hugo version compatibility check */}}
+    {{ partial "common/hugo-version-check.html" . }}
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     {{ hugo.Generator }}
     <link rel="icon" href="{{ .Site.Params.favicon | absURL }}" type="image/x-icon">

--- a/layouts/partials/common/hugo-version-check.html
+++ b/layouts/partials/common/hugo-version-check.html
@@ -26,6 +26,6 @@
   {{/* Extended version check */}}
   {{ if and $extendedRequired (not hugo.IsExtended) }}
     {{ $installCmd := printf $toInstallCmd hugo.Version }}
-    {{ errorf "❌ You are using the standard Hugo version. This module requires the Hugo extended edition.\n\n%s" (printf $toInstallRecommended $installCmd) }}
+    {{ warnf "⚠️ You are using the standard Hugo version. This module requires the Hugo extended edition.\n\n%s" (printf $toInstallRecommended $installCmd) }}
   {{ end }}
 {{ end }}

--- a/layouts/partials/common/hugo-version-check.html
+++ b/layouts/partials/common/hugo-version-check.html
@@ -8,8 +8,8 @@
   
   {{ $recommendMessage := printf "✅ Recommended: Hugo %s%s" $maxVersion $extendedText }}
 
-  {{ $toInstallCmd := "CGO_ENABLED=1 go install -tags extended github.com/gohugoio/hugo@v%s" }}
-  {{ $toInstallRecommended := "🔧 To install the recommended version:\n %s" }}
+  {{ $toInstallCmd := "\nCGO_ENABLED=1 go install -tags extended github.com/gohugoio/hugo@v%s" }}
+  {{ $toInstallRecommended := "🔧 To install the recommended version (see https://gohugo.io/installation/macos/#build-from-source): \n %s" }}
 
   {{/* Min version check */}}
   {{ if and $minVersion (lt hugo.Version $minVersion) }}

--- a/layouts/partials/common/hugo-version-check.html
+++ b/layouts/partials/common/hugo-version-check.html
@@ -1,0 +1,31 @@
+{{/* Hugo version compatibility check */}}
+{{ $config := $.Site.Params.hugoVersion }}
+{{ if and $config $config.enabled }}
+  {{ $minVersion := $config.min }}
+  {{ $maxVersion := $config.max }}
+  {{ $extendedRequired := $config.extended | default true }}
+  {{ $extendedText := cond $extendedRequired "+extended" "" }}
+  
+  {{ $recommendMessage := printf "✅ Recommended: Hugo %s%s" $maxVersion $extendedText }}
+
+  {{ $toInstallCmd := "CGO_ENABLED=1 go install -tags extended github.com/gohugoio/hugo@v%s" }}
+  {{ $toInstallRecommended := "🔧 To install the recommended version:\n %s" }}
+
+  {{/* Min version check */}}
+  {{ if and $minVersion (lt hugo.Version $minVersion) }}
+    {{ $installCmd := printf $toInstallCmd $maxVersion }}
+    {{ warnf "⚠️  Your Hugo version (%s) is not compatible with our build pipeline: Min %s\n\n%s\n\n%s" hugo.Version $minVersion $recommendMessage (printf $toInstallRecommended $installCmd) }}
+  {{ end }}
+  
+  {{/* Max version check */}}
+  {{ if and $maxVersion (gt hugo.Version $maxVersion) }}
+      {{ $installCmd := printf $toInstallCmd $maxVersion }}
+      {{ warnf "⚠️  Your Hugo version (%s) is not compatible with our build pipeline: Max %s\n\n%s\n\n%s" hugo.Version $maxVersion $recommendMessage (printf $toInstallRecommended $installCmd) }}
+  {{ end }}
+  
+  {{/* Extended version check */}}
+  {{ if and $extendedRequired (not hugo.IsExtended) }}
+    {{ $installCmd := printf $toInstallCmd hugo.Version }}
+    {{ errorf "❌ You are using the standard Hugo version. This module requires the Hugo extended edition.\n\n%s" (printf $toInstallRecommended $installCmd) }}
+  {{ end }}
+{{ end }}

--- a/theme.toml
+++ b/theme.toml
@@ -3,12 +3,12 @@
 
 name = "presidium-layouts-base"
 license = "MIT"
-licenselink = "https://github.com/yourname/yourtheme/blob/main/LICENSE"
+licenselink = "https://github.com/SPANDigital/presidium-layouts-base/blob/main/LICENSE"
 description = ""
 homepage = "http://example.com/"
 tags = []
 features = []
-min_version = "0.41.0"
+min_version = "0.133.0"
 
 [author]
   name = ""


### PR DESCRIPTION
## Description

Adds a Hugo version compatibility check to alert users if their local version of Hugo is not compatible with the version of Hugo used in Presidium's build pipeline. It also checks if the Hugo `extended` edition is installed.

This will warn the user and provide instructions to install an appropriate verison.

This should help prevent issues where local builds work but fail in the builder due to Hugo version incompatiblities.


## Issue
- [ ] :clipboard: [PRSDM-8658](https://spandigital.atlassian.net/browse/PRSDM-8658)

## Screenshots

+ local < min:
<img width="1182" height="249" alt="Screenshot 2025-08-19 at 12 58 19" src="https://github.com/user-attachments/assets/3549e2e0-4c28-42fd-888d-26d41b5fbcc3" />

+ local > max:
<img width="1182" height="249" alt="Screenshot 2025-08-19 at 12 58 51" src="https://github.com/user-attachments/assets/122875b9-9230-4536-934e-84c42fb29d75" />

+ !extended:
<img width="684" height="116" alt="Screenshot 2025-08-19 at 13 02 43" src="https://github.com/user-attachments/assets/970fda22-21af-4ea2-bc72-f7d473884cb6" />

## PR Readiness Checks
- [x] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [x] You have performed a self-review of your changes via the GitHub UI
- [x] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [x] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
