### PR TITLE
fix: PRSDM-9070 (resolve duplications in SEARCHMAP.JSON)

### DIFF
--- a/layouts/partials/searchmap/root.html
+++ b/layouts/partials/searchmap/root.html
@@ -1,8 +1,33 @@
 {{ $items := slice }}
+{{ $processedPaths := dict }}
 
-{{ range (union .Site.RegularPages .Site.Sections) }}
-    {{ range $searchmapItem := (partial "searchmap/item" (dict "Page" . "Level" 1)) }}
-        {{ $items = $items | append $searchmapItem }}
+{{/* Use Site.AllPages and filter for top-level pages to avoid duplicates */}}
+{{ range .Site.AllPages }}
+    {{ if .File }}
+        {{ $filePath := .File.Path }}
+        {{ if not (index $processedPaths $filePath) }}
+            {{/* Mark this page as processed immediately to prevent duplicate processing */}}
+            {{ $processedPaths = merge $processedPaths (dict $filePath true) }}
+
+        {{/* Only process if this is a top-level page (no parent or parent has no file) */}}
+        {{ $isTopLevel := true }}
+        {{ if .Parent }}
+            {{ if and .Parent.File (ne .Parent.Kind "home") }}
+                {{ $isTopLevel = false }}
+            {{ end }}
+        {{ end }}
+
+            {{ if $isTopLevel }}
+                {{/* Process this page */}}
+                {{ range $searchmapItem := (partial "searchmap/item" (dict "Page" . "Level" 1)) }}
+                    {{ $items = $items | append $searchmapItem }}
+                    {{/* Also mark any child page IDs as processed to prevent duplication */}}
+                    {{ if ne $searchmapItem.id $filePath }}
+                        {{ $processedPaths = merge $processedPaths (dict $searchmapItem.id true) }}
+                    {{ end }}
+                {{ end }}
+            {{ end }}
+        {{ end }}
     {{ end }}
 {{ end }}
 

--- a/layouts/partials/searchmap/root.html
+++ b/layouts/partials/searchmap/root.html
@@ -1,32 +1,11 @@
 {{ $items := slice }}
-{{ $processedPaths := dict }}
+{{ $seenItems := dict }}
 
-{{/* Use Site.AllPages and filter for top-level pages to avoid duplicates */}}
-{{ range .Site.AllPages }}
-    {{ if .File }}
-        {{ $filePath := .File.Path }}
-        {{ if not (index $processedPaths $filePath) }}
-            {{/* Mark this page as processed immediately to prevent duplicate processing */}}
-            {{ $processedPaths = merge $processedPaths (dict $filePath true) }}
-
-        {{/* Only process if this is a top-level page (no parent or parent has no file) */}}
-        {{ $isTopLevel := true }}
-        {{ if .Parent }}
-            {{ if and .Parent.File (ne .Parent.Kind "home") }}
-                {{ $isTopLevel = false }}
-            {{ end }}
-        {{ end }}
-
-            {{ if $isTopLevel }}
-                {{/* Process this page */}}
-                {{ range $searchmapItem := (partial "searchmap/item" (dict "Page" . "Level" 1)) }}
-                    {{ $items = $items | append $searchmapItem }}
-                    {{/* Also mark any child page IDs as processed to prevent duplication */}}
-                    {{ if ne $searchmapItem.id $filePath }}
-                        {{ $processedPaths = merge $processedPaths (dict $searchmapItem.id true) }}
-                    {{ end }}
-                {{ end }}
-            {{ end }}
+{{ range (union .Site.RegularPages .Site.Sections) }}
+    {{ range $searchmapItem := (partial "searchmap/item" (dict "Page" . "Level" 1)) }}
+        {{ if not (index $seenItems $searchmapItem.id) }}
+            {{ $items = $items | append $searchmapItem }}
+            {{ $seenItems = merge $seenItems (dict $searchmapItem.id true) }}
         {{ end }}
     {{ end }}
 {{ end }}


### PR DESCRIPTION
## Description

Resolve duplications in SEARCHMAP.JSON

## Issue
- https://spandigital.atlassian.net/browse/PRSDM-9079

## Screenshots

## To Test

* First loadSite with content builder, then pull out duplications in searchmap.json

* `jq -r '.[].url' presidium-services/web/static/docs/span-chronicle/searchmap.json | sort | uniq -d | wc -l`

* Checkout this code, update span-chronicle go.mod to replace layouts-base with your local checkout.

* Run loadSite and then test for duplications.

On the ticket is a Python script you can run to give you more detailed validation

* Make a copy of the old searchmap
* create new searchmap
*  run script to compare

```bash
Searchmap Comparison Tool
==================================================
Loading searchmap files...
Old searchmap: 1101 records
New searchmap: 615 records

Duplication analysis:
Old searchmap unique records: 615
Old searchmap duplicates: 486
New searchmap unique records: 615
New searchmap duplicates: 0

Bidirectional comparison results:
Records in old but NOT in new: 0
Records in new but NOT in old: 0
Unique record sets are identical: YES

[SUCCESS] All unique records from old searchmap are present in new searchmap!

[SUCCESS] All unique records from new searchmap are present in old searchmap!
==================================================
SUMMARY:
==================================================
[SUCCESS] All unique records from old searchmap exist in new searchmap
[SUCCESS] All unique records from new searchmap exist in old searchmap
[SUCCESS] Both files contain exactly the same unique records
[IMPROVEMENT] Duplicates reduced from 486 to 0
```

## PR Readiness Checks
- [x] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [x] You have performed a self-review of your changes via the GitHub UI
- [x] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [ ] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
