### PR TITLE
feat: PRSDM-9510 update cli guidance logging on build failures

### DIFF
--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -9,10 +9,12 @@
 {{- if not $validation.valid -}}
   {{- $namespace := .Site.Params.data.namespace | default "presidium" -}}
   {{- $schemaLocation := printf "data/%s/frontmatter-schema.yaml" $namespace -}}
-  {{ warnf "[Frontmatter Validation] There are errors in the frontmatter of one or more articles - see below." }}
-  {{ warnf "[Frontmatter Validation] Review the schema for frontmatter located at %s." $schemaLocation }}
+  {{- errorf "=====================================================================================================================================" -}}
+  {{- errorf "[Frontmatter Validation] Errors in the frontmatter of one or more articles are logged below." -}}
+  {{- errorf "[Frontmatter Validation] Review article frontmatter against the frontmatter schema located at %s." $schemaLocation -}}
+  {{- errorf "===================================================================================================================================== " -}}
   {{- range $error := $validation.errors -}}
-    {{- warnf "[Frontmatter Validation] %s: %s" $.File.Path $error -}}
+    {{- errorf "[Frontmatter Validation] %s: %s" $.File.Path $error -}}
   {{- end -}}
 {{- end -}}
 <section data-section="{{ strings.TrimPrefix "/" .Parent.Path }}">

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -7,6 +7,10 @@
 {{- partial "frontmatter/validate.html" . -}}
 {{- $validation := .Scratch.Get "frontmatter_validation" -}}
 {{- if not $validation.valid -}}
+  {{- $namespace := .Site.Params.data.namespace | default "presidium" -}}
+  {{- $schemaLocation := printf "data/%s/frontmatter-schema.yaml" $namespace -}}
+  {{ warnf "[Frontmatter Validation] There are errors in the frontmatter of one or more articles - see below." }}
+  {{ warnf "[Frontmatter Validation] Review the schema for frontmatter located at %s." $schemaLocation }}
   {{- range $error := $validation.errors -}}
     {{- warnf "[Frontmatter Validation] %s: %s" $.File.Path $error -}}
   {{- end -}}


### PR DESCRIPTION
## Description

## Issue
- [x] :clipboard: [JIRA_TICKET_URL](https://spandigital.atlassian.net/browse/PRSDM-9510)

## Screenshots

Build with errors now starts with:

```
% hugo --gc
Start building sites … 
hugo v0.147.7-189453612e4bedc4f27495a7b1145321c8d89807+extended darwin/arm64 BuildDate=2025-05-31T12:41:12Z VendorInfo=gohugoio

ERROR =====================================================================================================================================
ERROR [Frontmatter Validation] Errors in the frontmatter of one or more articles are logged below.
ERROR [Frontmatter Validation] Review article frontmatter against the frontmatter schema located at data/presidium/frontmatter-schema.yaml.
ERROR =====================================================================================================================================
ERROR [Frontmatter Validation] career-development/03-learning-and-training.md: status must be one of: draft, published, archived
ERROR [Frontmatter Validation] career-development/04-performance-reviews.md: status must be one of: draft, published, archived
ERROR [Frontmatter Validation] career-development/02-growth-planning.md: status must be one of: draft, published, archived
ERROR [Frontmatter Validation] glossary/hlp.md: Title must be at least 5 characters
ERROR [Frontmatter Validation] glossary/loe.md: Title must be at least 5 characters
```
...


## PR Readiness Checks
- [x] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [x] You have performed a self-review of your changes via the GitHub UI
- [x] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [ ] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
