### PR TITLE
fix: PRSDM-10292 Render nav state server-side to avoid flicker

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -27,7 +27,7 @@
           }
         }
       } catch (error) {
-        // localStorage may be unavailable, so skip width restoration silently.
+        console.error('Failed to restore sidenav width from localStorage.', error);
       }
     </script>
     <style>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -69,7 +69,7 @@
             document.querySelector('#presidium-navigation').innerHTML = window.navigation;
           </script>
         {{ else }}
-          {{ partialCached "navigation/root" . 0 }}
+          {{ partial "navigation/root" . }}
         {{ end }}
       </div>
       <div id="resizer"></div>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -21,9 +21,13 @@
       try {
         const savedWidth = window.localStorage.getItem('sidenav');
         if (savedWidth) {
-          document.documentElement.style.setProperty('--presidium-sidenav-width', savedWidth);
+          const parsedWidth = Number.parseInt(savedWidth, 10);
+          if (!Number.isNaN(parsedWidth) && parsedWidth >= 300 && parsedWidth <= 600) {
+            document.documentElement.style.setProperty('--presidium-sidenav-width', `${parsedWidth}px`);
+          }
         }
       } catch (error) {
+        // localStorage may be unavailable, so skip width restoration silently.
       }
     </script>
     <style>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -17,6 +17,22 @@
         <link rel="stylesheet" href="{{ .RelPermalink }}">
       {{ end }}
     {{ end }}
+    <script>
+      try {
+        const savedWidth = window.localStorage.getItem('sidenav');
+        if (savedWidth) {
+          document.documentElement.style.setProperty('--presidium-sidenav-width', savedWidth);
+        }
+      } catch (error) {
+      }
+    </script>
+    <style>
+      @media (min-width: 992px) {
+        #presidium-navigation {
+          flex-basis: var(--presidium-sidenav-width, 300px);
+        }
+      }
+    </style>
 
     {{ if $.Site.Params.enterprise_enabled }}
       {{ $enterpriseScript := $.Site.Params.enterprise_script | default "/presidium-enterprise.js" }}

--- a/layouts/partials/navigation/nav-item.html
+++ b/layouts/partials/navigation/nav-item.html
@@ -3,6 +3,7 @@
 {{ $roles := .NavPage.Params.roles | default "All Roles" }}
 {{/* rootUrl is the baseUrl but it defaults to "/" if no baseUrl is set */}}
 {{ $rootUrl := .RootUrl }}
+{{ $currentPage := .CurrentPage | default .NavPage }}
 
 {{/* Use title if no slug */}}
 {{ $slug := humanize .NavPage.Params.Title }} {{/* Handles any dashes in the title */}}
@@ -31,12 +32,9 @@
     {{ end }}
 {{end}}
 
-{{/* combines the parent slug with the current slug to ensure it's globally unique */}}
-{{ $pageSlug := (printf "%v-%v" ($parentSlug) $slug )}}
-
 {{/*  Hide the first item if the title is the same as the parent  */}}
 {{ $offset := 0 }}
-{{ if eq (index .NavPage.Data.Pages 0).Title .NavPage.Title }}
+{{ if and (gt (len .NavPage.Data.Pages) 0) (eq (index .NavPage.Data.Pages 0).Title .NavPage.Title) }}
     {{ $offset = 1 }}
 {{ end }}
 {{ $hasChildren := lt $offset (len .NavPage.Data.Pages)}}
@@ -48,14 +46,17 @@
 {{ $uid := .NavPage.File.UniqueID }}
 {{- $importInfo := partial "common/is-imported" .NavPage -}}
 {{- $isImported := $importInfo.isImported -}}
+{{ $articlePath := replaceRE "#.*$" "" $articleLink }}
+{{ $isCurrentItem := eq $articlePath $currentPage.RelPermalink }}
+{{ $isOpen := and $hasChildren (or $isCurrentItem (.NavPage.IsAncestor $currentPage)) }}
 
-<li class="menu-row {{ if .NavPage.IsPage }}child{{end}}" style="overflow: hidden;" data-roles="{{ $roles }}" {{ if .NavPage.Site.Params.enterprise_enabled }} data-imported="{{ $isImported }}" {{ end }}>
+<li class="menu-row {{ if .NavPage.IsPage }}child{{end}}{{ if $hasChildren }} {{ if $isOpen }}open{{ else }}closed{{ end }}{{ end }}" style="overflow: hidden;" data-roles="{{ $roles }}" {{ if .NavPage.Site.Params.enterprise_enabled }} data-imported="{{ $isImported }}" {{ end }}>
     <div class="link level-{{ .Level }}">
         <!-- data-target is used by the scrollspy on presidium-js to determine which section of the page the <a> corresponds to -->
         <a class="level-{{ .Level }} {{ if eq .Index 0 }}first-child{{end}}" data-slug="{{ $slug }}" data-target="#{{$uid}}" data-id="{{ $articleId }}" href="{{ $articleLink }}">
             {{ if $hasChildren }}
                 <div class="menu-expander" aria-controls="{{$uid}}">
-                    <span class="glyphicon glyphicon-chevron-right glyphicon-toggle"></span>
+                    <span class="glyphicon {{ if $isOpen }}glyphicon-chevron-down{{ else }}glyphicon-chevron-right{{ end }} glyphicon-toggle"></span>
                 </div>
             {{ end }}
             <div class="menu-title">
@@ -67,7 +68,7 @@
     </div>
 
     {{ if $hasChildren }}
-        <ul id="{{$uid}}" class="collapse">
+        <ul id="{{$uid}}" class="collapse{{ if $isOpen }} in active show{{ end }}">
             {{ $pages := (partial "common/pages" .NavPage )}}
             {{/* Sort by filename if specified in config */}}
             {{ $sortByFilePath := .NavPage.Params.sortByFilePath | default .NavPage.Site.Params.sortByFilePath }}
@@ -75,11 +76,11 @@
                 {{ $sortOrder := (partial "common/sortorder" (dict "SortByFilePath" $sortByFilePath)) }}
                 {{/* Sort by file prefix */}}
                 {{ range $index, $subMenu := (sort (after $offset $pages) "File.Path" $sortOrder) }}
-                    {{ partial "navigation/nav-item" (dict "NavPage" $subMenu "Level" $childLevel "Index" $index "RootUrl" $rootUrl "SlugifyUrl" $slugifyUrl ) }}
+                    {{ partial "navigation/nav-item" (dict "NavPage" $subMenu "CurrentPage" $currentPage "Level" $childLevel "Index" $index "RootUrl" $rootUrl "SlugifyUrl" $slugifyUrl ) }}
                 {{ end }}
             {{ else }}
                 {{ range $index, $subMenu := after $offset $pages }}
-                    {{ partial "navigation/nav-item" (dict "NavPage" $subMenu "Level" $childLevel "Index" $index "RootUrl" $rootUrl "SlugifyUrl" $slugifyUrl ) }}
+                    {{ partial "navigation/nav-item" (dict "NavPage" $subMenu "CurrentPage" $currentPage "Level" $childLevel "Index" $index "RootUrl" $rootUrl "SlugifyUrl" $slugifyUrl ) }}
                 {{ end }}
             {{ end }}
         </ul>

--- a/layouts/partials/navigation/nav-item.html
+++ b/layouts/partials/navigation/nav-item.html
@@ -21,6 +21,9 @@
     {{ $parentSlug = .NavPage.Parent.Params.Slug}}
 {{ end }}
 
+{{/* combines the parent slug with the current slug to ensure it's globally unique */}}
+{{ $pageSlug := (printf "%v-%v" ($parentSlug) $slug )}}
+
 {{/* adds the slug to the link if the article has no children */}}
 {{ $articleLink := .NavPage.RelPermalink }}
 {{if and .NavPage.IsPage $slugifyUrl }}
@@ -34,7 +37,7 @@
 
 {{/*  Hide the first item if the title is the same as the parent  */}}
 {{ $offset := 0 }}
-{{ if and (gt (len .NavPage.Data.Pages) 0) (eq (index .NavPage.Data.Pages 0).Title .NavPage.Title) }}
+{{ if eq (index .NavPage.Data.Pages 0).Title .NavPage.Title }}
     {{ $offset = 1 }}
 {{ end }}
 {{ $hasChildren := lt $offset (len .NavPage.Data.Pages)}}

--- a/layouts/partials/navigation/nav-item.html
+++ b/layouts/partials/navigation/nav-item.html
@@ -58,7 +58,7 @@
         <!-- data-target is used by the scrollspy on presidium-js to determine which section of the page the <a> corresponds to -->
         <a class="level-{{ .Level }} {{ if eq .Index 0 }}first-child{{end}}" data-slug="{{ $slug }}" data-target="#{{$uid}}" data-id="{{ $articleId }}" href="{{ $articleLink }}">
             {{ if $hasChildren }}
-                <div class="menu-expander" aria-controls="{{$uid}}">
+                <div class="menu-expander" aria-controls="{{$uid}}" aria-expanded="{{ if $isOpen }}true{{ else }}false{{ end }}">
                     <span class="glyphicon {{ if $isOpen }}glyphicon-chevron-down{{ else }}glyphicon-chevron-right{{ end }} glyphicon-toggle"></span>
                 </div>
             {{ end }}

--- a/layouts/partials/navigation/nav-item.html
+++ b/layouts/partials/navigation/nav-item.html
@@ -48,9 +48,9 @@
 {{- $isImported := $importInfo.isImported -}}
 {{ $articlePath := replaceRE "#.*$" "" $articleLink }}
 {{ $isCurrentItem := eq $articlePath $currentPage.RelPermalink }}
-{{ $isOpen := and $hasChildren (or $isCurrentItem (.NavPage.IsAncestor $currentPage)) }}
+{{ $isOpen := or $isCurrentItem (and $hasChildren (.NavPage.IsAncestor $currentPage)) }}
 
-<li class="menu-row {{ if .NavPage.IsPage }}child{{end}}{{ if $hasChildren }} {{ if $isOpen }}open{{ else }}closed{{ end }}{{ end }}" style="overflow: hidden;" data-roles="{{ $roles }}" {{ if .NavPage.Site.Params.enterprise_enabled }} data-imported="{{ $isImported }}" {{ end }}>
+<li class="menu-row {{ if .NavPage.IsPage }}child{{end}}{{ if $isOpen }} open{{ else if $hasChildren }} closed{{ end }}" style="overflow: hidden;" data-roles="{{ $roles }}" {{ if .NavPage.Site.Params.enterprise_enabled }} data-imported="{{ $isImported }}" {{ end }}>
     <div class="link level-{{ .Level }}">
         <!-- data-target is used by the scrollspy on presidium-js to determine which section of the page the <a> corresponds to -->
         <a class="level-{{ .Level }} {{ if eq .Index 0 }}first-child{{end}}" data-slug="{{ $slug }}" data-target="#{{$uid}}" data-id="{{ $articleId }}" href="{{ $articleLink }}">

--- a/layouts/partials/navigation/root.html
+++ b/layouts/partials/navigation/root.html
@@ -6,7 +6,6 @@
 
 <nav class="navbar">
   <div class="navbar-items">
-    {{ $currentPage := . }}
     <ul class="navbar-nav">
       {{ range $menu := .Site.Menus.main.ByWeight }} 
         {{ $isRendering := true }} 
@@ -22,7 +21,7 @@
           {{ else }}
             {{ $identifier := anchorize $menu.Identifier }}
             {{ with $.Site.GetPage $identifier }}
-              {{ partial "navigation/nav-item" (dict "NavPage" . "MenuName" $menu.Name "Level" 1 "Expanded" true "Collapsed" $menu.Params.Collapsed "RootUrl" $rootUrl "Show" false "SlugifyUrl" $slugifyUrl ) }}
+              {{ partial "navigation/nav-item" (dict "NavPage" . "CurrentPage" $ "MenuName" $menu.Name "Level" 1 "Expanded" true "Collapsed" $menu.Params.Collapsed "RootUrl" $rootUrl "Show" false "SlugifyUrl" $slugifyUrl ) }}
             {{ end }}
           {{ end }} 
         {{ end }} 

--- a/layouts/partials/page/script.html
+++ b/layouts/partials/page/script.html
@@ -110,6 +110,66 @@
   });
 </script>
 
+{{ if $.Site.Params.resizeMenu | default true }}
+<script type="module">
+  const desktopSize = window.matchMedia('(min-width: 992px)');
+  const resizer = document.querySelector('#resizer');
+  const sidebar = document.querySelector('#presidium-navigation');
+  const minWidth = 300;
+  const maxWidth = 600;
+  let isResizing = false;
+
+  const clampWidth = (value) => {
+    return Math.min(maxWidth, Math.max(minWidth, value));
+  };
+
+  const applyWidth = (value) => {
+    const width = `${clampWidth(value)}px`;
+    document.documentElement.style.setProperty('--presidium-sidenav-width', width);
+    try {
+      window.localStorage.setItem('sidenav', width);
+    } catch (error) {
+    }
+  };
+
+  const syncResizeMode = () => {
+    if (!resizer || !sidebar) return;
+    resizer.style.display = desktopSize.matches ? 'block' : 'none';
+  };
+
+  const stopResizing = () => {
+    isResizing = false;
+    document.removeEventListener('mousemove', onMouseMove, false);
+    document.removeEventListener('mouseup', stopResizing, false);
+  };
+
+  const onMouseMove = (event) => {
+    if (!isResizing) return;
+    applyWidth(event.clientX);
+  };
+
+  syncResizeMode();
+
+  const cachedSize = window.localStorage.getItem('sidenav');
+  if (desktopSize.matches && cachedSize) {
+    const parsedSize = Number.parseInt(cachedSize, 10);
+    if (!Number.isNaN(parsedSize)) {
+      applyWidth(parsedSize);
+    }
+  }
+
+  desktopSize.addEventListener('change', syncResizeMode);
+
+  resizer?.addEventListener('mousedown', (event) => {
+    if (!desktopSize.matches) return;
+    event.preventDefault();
+    isResizing = true;
+    document.addEventListener('mousemove', onMouseMove, false);
+    document.addEventListener('mouseup', stopResizing, false);
+  });
+</script>
+{{ end }}
+
 {{ if $.Site.Params.enableSublinks }}
 <script type="module">
   (function addHeadingLinks(){

--- a/layouts/partials/page/script.html
+++ b/layouts/partials/page/script.html
@@ -159,6 +159,7 @@
     try {
       window.localStorage.setItem('sidenav', width);
     } catch (error) {
+      // localStorage may be unavailable, so skip persisting the resized width.
     }
   };
 

--- a/layouts/partials/page/script.html
+++ b/layouts/partials/page/script.html
@@ -27,7 +27,6 @@
     $menu.toggleClass('expanded', !isOpen).toggleClass('', isOpen);
   });
 
-  // Handle collapsing of nav-items
   const toggleMenu = ($menu, isOpen) => {
     const $ul = $menu.find('ul').first();
 
@@ -44,7 +43,6 @@
             .toggleClass('glyphicon-chevron-right', !isOpen);
   };
 
-  // Bootstrap collapse events
   $('li.menu-row').on('show.bs.collapse', (event) => {
     event.stopPropagation();
     const $menu = $(event.currentTarget);
@@ -73,39 +71,25 @@
     $ul.collapse('toggle');
   });
 
-  // Recursively open the current page's menu nav
-  let navItem = $(`a[href="${window.location.pathname}"]`).parent().closest('.menu-row');
-  while (navItem.length) {
-      toggleMenu(navItem, true);
-      navItem = navItem.parent().closest('.menu-row');
-  }
-
   function copyPermalink(link, articleLink, copyTitle) {
-      // Remove the leading slash from articleLink if present
       if (articleLink.startsWith('/')) {
-          articleLink = articleLink.substring(1); // Remove the leading slash
+          articleLink = articleLink.substring(1);
       }
-      // Copy the article link to the clipboard
       const fullURL = window.location.origin + '/' + articleLink;
       navigator.clipboard.writeText(fullURL);
 
-      // Show toast message
       const toast = document.querySelector('#copy-toast');
       if (toast) {
-          // set popup-copy-text
-          const popupCopyText = toast.querySelector('.popup-copy-text')
+          const popupCopyText = toast.querySelector('.popup-copy-text');
           popupCopyText.innerHTML = `Copied link to ${copyTitle}`;
-          // show toast
           toast.style.opacity = '1';
           toast.classList.add("show");
           setTimeout(function () {
               toast.style.opacity = '0';
               toast.classList.remove("show");
           }, 3000);
-          console.log(`Copied link to ${copyTitle}`);
       }
   }
-  // Assign the function to the global scope
   window.copyPermalink = copyPermalink;
 
   window.presidium?.tooltips?.load();
@@ -122,67 +106,9 @@
             'lineColor': '#666',
         },
     });
-    // Explicitly initialize all Mermaid diagrams
     mermaid.init(undefined, document.querySelectorAll('.mermaid'));
   });
-
-  // Ensure nav-items fit within the viewport without overlapping the header
-  document.addEventListener("DOMContentLoaded", function () {
-    const navbarHeader = document.querySelector(".navbar-header");
-    const navbarItems = document.querySelector(".navbar-items");
-
-    if (navbarHeader && navbarItems) {
-      // Calculate the dynamic height and apply it
-      const headerHeight = navbarHeader.offsetHeight;
-      navbarItems.style.maxHeight = `calc(100vh - ${headerHeight}px)`;
-    }
-
-    // Adjust height dynamically during window resize
-    window.addEventListener("resize", function () {
-      if (navbarHeader && navbarItems) {
-        const headerHeight = navbarHeader.offsetHeight;
-        navbarItems.style.maxHeight = `calc(100vh - ${headerHeight}px)`;
-      }
-    });
-  });
 </script>
-
-{{ if $.Site.Params.resizeMenu | default true }}
-<script type="module">
-    const desktopSize = window.matchMedia("(min-width: 992px)")
-    const resizer = document.querySelector("#resizer");
-    const sidebar = document.querySelector("#presidium-navigation");
-    const cachedSize = window.localStorage.getItem('sidenav');
-
-    if (cachedSize === null) {
-      window.localStorage.setItem('sidenav', '300px');
-      location.reload();
-    }
-
-    if(desktopSize.matches) {
-      resizer.style.display = 'block';
-
-      if (cachedSize) {
-        sidebar.style.flexBasis = cachedSize;
-      }
-    }
-
-    resizer.addEventListener("mousedown", (event) => {
-      event.preventDefault();
-      document.addEventListener("mousemove", resize, false);
-      document.addEventListener("mouseup", () => {
-        event.preventDefault();
-        document.removeEventListener("mousemove", resize, false);
-      }, false);
-    });
-
-    function resize(e) {
-      const size = `${e.x}px`;
-      window.localStorage.setItem('sidenav', size);
-      sidebar.style.flexBasis = size;
-    }
-</script>
-{{ end }}
 
 {{ if $.Site.Params.enableSublinks }}
 <script type="module">

--- a/layouts/partials/page/script.html
+++ b/layouts/partials/page/script.html
@@ -71,13 +71,6 @@
     $ul.collapse('toggle');
   });
 
-  // Recursively open the current page's menu nav
-  let navItem = $(`a[href="${window.location.pathname}"]`).parent().closest('.menu-row');
-  while (navItem.length) {
-      toggleMenu(navItem, true);
-      navItem = navItem.parent().closest('.menu-row');
-  }
-
   function copyPermalink(link, articleLink, copyTitle) {
       if (articleLink.startsWith('/')) {
           articleLink = articleLink.substring(1);

--- a/layouts/partials/page/script.html
+++ b/layouts/partials/page/script.html
@@ -27,6 +27,7 @@
     $menu.toggleClass('expanded', !isOpen).toggleClass('', isOpen);
   });
 
+  // Handle collapsing of nav-items
   const toggleMenu = ($menu, isOpen) => {
     const $ul = $menu.find('ul').first();
 
@@ -43,6 +44,7 @@
             .toggleClass('glyphicon-chevron-right', !isOpen);
   };
 
+  // Bootstrap collapse events
   $('li.menu-row').on('show.bs.collapse', (event) => {
     event.stopPropagation();
     const $menu = $(event.currentTarget);
@@ -72,24 +74,31 @@
   });
 
   function copyPermalink(link, articleLink, copyTitle) {
+      // Remove the leading slash from articleLink if present
       if (articleLink.startsWith('/')) {
-          articleLink = articleLink.substring(1);
+          articleLink = articleLink.substring(1); // Remove the leading slash
       }
+      // Copy the article link to the clipboard
       const fullURL = window.location.origin + '/' + articleLink;
       navigator.clipboard.writeText(fullURL);
 
+      // Show toast message
       const toast = document.querySelector('#copy-toast');
       if (toast) {
+          // set popup-copy-text
           const popupCopyText = toast.querySelector('.popup-copy-text');
           popupCopyText.innerHTML = `Copied link to ${copyTitle}`;
+          // show toast
           toast.style.opacity = '1';
           toast.classList.add("show");
           setTimeout(function () {
               toast.style.opacity = '0';
               toast.classList.remove("show");
           }, 3000);
+          console.log(`Copied link to ${copyTitle}`);
       }
   }
+  // Assign the function to the global scope
   window.copyPermalink = copyPermalink;
 
   window.presidium?.tooltips?.load();
@@ -106,7 +115,28 @@
             'lineColor': '#666',
         },
     });
+    // Explicitly initialize all Mermaid diagrams
     mermaid.init(undefined, document.querySelectorAll('.mermaid'));
+  });
+
+  // Ensure nav-items fit within the viewport without overlapping the header
+  document.addEventListener("DOMContentLoaded", function () {
+    const navbarHeader = document.querySelector(".navbar-header");
+    const navbarItems = document.querySelector(".navbar-items");
+
+    if (navbarHeader && navbarItems) {
+      // Calculate the dynamic height and apply it
+      const headerHeight = navbarHeader.offsetHeight;
+      navbarItems.style.maxHeight = `calc(100vh - ${headerHeight}px)`;
+    }
+
+    // Adjust height dynamically during window resize
+    window.addEventListener("resize", function () {
+      if (navbarHeader && navbarItems) {
+        const headerHeight = navbarHeader.offsetHeight;
+        navbarItems.style.maxHeight = `calc(100vh - ${headerHeight}px)`;
+      }
+    });
   });
 </script>
 

--- a/layouts/partials/page/script.html
+++ b/layouts/partials/page/script.html
@@ -71,6 +71,13 @@
     $ul.collapse('toggle');
   });
 
+  // Recursively open the current page's menu nav
+  let navItem = $(`a[href="${window.location.pathname}"]`).parent().closest('.menu-row');
+  while (navItem.length) {
+      toggleMenu(navItem, true);
+      navItem = navItem.parent().closest('.menu-row');
+  }
+
   function copyPermalink(link, articleLink, copyTitle) {
       if (articleLink.startsWith('/')) {
           articleLink = articleLink.substring(1);

--- a/layouts/partials/page/script.html
+++ b/layouts/partials/page/script.html
@@ -42,6 +42,7 @@
     const $trigger = $menu.find('div.menu-expander > .glyphicon').first();
     $trigger.toggleClass('glyphicon-chevron-down', isOpen)
             .toggleClass('glyphicon-chevron-right', !isOpen);
+    $menu.find('div.menu-expander').first().attr('aria-expanded', isOpen ? 'true' : 'false');
   };
 
   // Bootstrap collapse events
@@ -181,7 +182,12 @@
 
   syncResizeMode();
 
-  const cachedSize = window.localStorage.getItem('sidenav');
+  let cachedSize = null;
+  try {
+    cachedSize = window.localStorage.getItem('sidenav');
+  } catch (error) {
+    // localStorage may be unavailable, so fall back to the default sidenav width.
+  }
   if (desktopSize.matches && cachedSize) {
     const parsedSize = Number.parseInt(cachedSize, 10);
     if (!Number.isNaN(parsedSize)) {


### PR DESCRIPTION
## Description
This updates the shared left-nav rendering so the correct branch is already open in the initial HTML instead of being reshaped after page load.

The change removes the main post-load sidebar mutations that were causing the visible flicker on SPAN sites and renders the current nav state on the server instead.

Changes included:
- render the current nav branch as open on the server
- pass the current page through recursive nav item rendering
- stop using a single global cached nav partial so nav state can vary per page
- remove post-load sidebar mutations for:
  - auto-opening the current branch
  - nav header height recalculation
  - sidebar width restore / reload behavior

## Issue
- [PRSDM-10292](https://spandigital.atlassian.net/browse/PRSDM-10292)

## Screenshots
The screenshot show four versions of the same SPAN site for comparison. The first tab shows the current lazy-loaded nav approach, the second shows the JSON-generated nav prototype, and the third shows the nav when the site is loaded into Presidium. In the Presidium view the flicker is not as noticeable because the full page, including the toolbar, reloads together. The fourth tab shows the fix included in this PR, where the nav state is rendered correctly up front and the flicker is removed.

https://github.com/user-attachments/assets/19875253-dbff-4bcb-953a-2a807018e897


## PR Readiness Checks
- [x] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [ ] You have performed a self-review of your changes via the GitHub UI
- [ ] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [ ] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
