### PR TITLE
fix: PRSDM-10468 and PRSDM-10467 implement nested field validation for object and array types

### DIFF
--- a/layouts/partials/frontmatter/validators/root.html
+++ b/layouts/partials/frontmatter/validators/root.html
@@ -32,7 +32,7 @@
     {{- end -}}
     {{- if not $validOption -}}
       {{- $optionsList := delimit $rules.options ", " -}}
-      {{- $message := printf "%s must be one of: %s" $fieldName $optionsList -}}
+      {{- $message := printf "%s: '%v' is not a valid value. Must be one of: %s" $fieldName $value $optionsList -}}
       {{- $errors = $errors | append $message -}}
       {{- $result = dict "valid" false "errors" $errors -}}
     {{- end -}}

--- a/layouts/partials/frontmatter/validators/types/array.html
+++ b/layouts/partials/frontmatter/validators/types/array.html
@@ -12,7 +12,34 @@
 {{- if not (hasPrefix $valueType "[]") -}}
   {{- $errors = $errors | append (printf "%s must be an array" $fieldName) -}}
 {{- else -}}
-  {{/* TODO: Validate each item against the nested field schema */}}
+  {{/* Validate each item against the nested field schema if defined */}}
+  {{- if $rules.field -}}
+    {{- range $i, $item := $value -}}
+      {{- $itemFieldName := printf "%s[%d]" $fieldName $i -}}
+      {{/* Synthetic pageParams: key is full qualified name so isset works correctly */}}
+      {{- $itemPageParams := dict $itemFieldName $item -}}
+      {{- partial "frontmatter/validators/root.html" (dict
+          "value" $item
+          "rules" $rules.field
+          "fieldName" $itemFieldName
+          "pageParams" $itemPageParams
+          "context" $ctx) -}}
+      {{- $itemResult := $ctx.Scratch.Get "validation_result" -}}
+      {{- if not $itemResult.valid -}}
+        {{- range $error := $itemResult.errors -}}
+          {{- $errors = $errors | append $error -}}
+          {{/* When parent has error_message, also emit directly so item-specific context is preserved */}}
+          {{- if $rules.error_message -}}
+            {{- if not (hasPrefix $error $itemFieldName) -}}
+              {{- warnf "[Frontmatter Validation] %s: %s: %s" $ctx.File.Path $itemFieldName $error -}}
+            {{- else -}}
+              {{- warnf "[Frontmatter Validation] %s: %s" $ctx.File.Path $error -}}
+            {{- end -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}
 
 {{/* Store result in scratch for retrieval by root validator */}}

--- a/layouts/partials/frontmatter/validators/types/number.html
+++ b/layouts/partials/frontmatter/validators/types/number.html
@@ -7,11 +7,12 @@
 {{- $ctx := .context -}}
 {{- $errors := slice -}}
 
-{{/* Type check - numbers can be int or float in Hugo */}}
+{{/* Type check - numbers can be int, uint, or float in Hugo */}}
 {{- $valueType := printf "%T" $value -}}
 {{- $isInt := or (eq $valueType "int") (eq $valueType "int64") -}}
+{{- $isUint := or (eq $valueType "uint") (eq $valueType "uint64") -}}
 {{- $isFloat := or (eq $valueType "float64") (eq $valueType "float32") -}}
-{{- $isNumber := or $isInt $isFloat -}}
+{{- $isNumber := or $isInt $isUint $isFloat -}}
 
 {{- if not $isNumber -}}
   {{- $errors = $errors | append (printf "%s must be a number" $fieldName) -}}

--- a/layouts/partials/frontmatter/validators/types/object.html
+++ b/layouts/partials/frontmatter/validators/types/object.html
@@ -9,12 +9,43 @@
 
 {{/* Type check: must be map/dict */}}
 {{- $valueType := printf "%T" $value -}}
-{{/* Accept both map[...] and maps.Params (Hugo's type for YAML objects) */}}
-{{- $isMap := or (hasPrefix $valueType "map[") (eq $valueType "maps.Params") -}}
+{{/* Accept map[...], maps.Params, and hmaps.Params (Hugo's internal param map type) */}}
+{{- $isMap := or (hasPrefix $valueType "map[") (hasSuffix $valueType "maps.Params") -}}
 {{- if not $isMap -}}
   {{- $errors = $errors | append (printf "%s must be an object" $fieldName) -}}
 {{- else -}}
-  {{/* TODO: Validate nested fields against schema */}}
+  {{/* Validate each nested field against its schema */}}
+  {{- range $nestedFieldName, $nestedRules := $rules.fields -}}
+    {{- $nestedValue := index $value $nestedFieldName -}}
+    {{- $nestedFieldPath := printf "%s.%s" $fieldName $nestedFieldName -}}
+    {{/* Only include key in pageParams when field exists in parent object.
+         Hugo's isset returns true for map keys with nil values, so we must
+         omit the key entirely when the field is absent. */}}
+    {{- $nestedPageParams := dict -}}
+    {{- if isset $value $nestedFieldName -}}
+      {{- $nestedPageParams = dict $nestedFieldPath $nestedValue -}}
+    {{- end -}}
+    {{- partial "frontmatter/validators/root.html" (dict
+        "value" $nestedValue
+        "rules" $nestedRules
+        "fieldName" $nestedFieldPath
+        "pageParams" $nestedPageParams
+        "context" $ctx) -}}
+    {{- $nestedResult := $ctx.Scratch.Get "validation_result" -}}
+    {{- if not $nestedResult.valid -}}
+      {{- range $error := $nestedResult.errors -}}
+        {{- $errors = $errors | append $error -}}
+        {{/* When parent has error_message, also emit directly so field-specific context is preserved */}}
+        {{- if $rules.error_message -}}
+          {{- if not (hasPrefix $error $nestedFieldPath) -}}
+            {{- warnf "[Frontmatter Validation] %s: %s: %s" $ctx.File.Path $nestedFieldPath $error -}}
+          {{- else -}}
+            {{- warnf "[Frontmatter Validation] %s: %s" $ctx.File.Path $error -}}
+          {{- end -}}
+        {{- end -}}
+      {{- end -}}
+    {{- end -}}
+  {{- end -}}
 {{- end -}}
 
 {{/* Store result in scratch for retrieval by root validator */}}


### PR DESCRIPTION
<!-- Keep descriptions under 200 words. -->

[PRSDM-10468](https://spandigital.atlassian.net/browse/PRSDM-10468)

## What does this PR do?

Implements nested field validation for `object` and `array` types that was previously marked as TODO.

- `object.html`: recursively validates each nested field via `root.html` calls; fixes `hmaps.Params` type check; correctly handles absent nested fields
- `array.html`: validates each array item against `$rules.field` schema
- `number.html`: adds `uint`/`uint64` support (Hugo represents YAML integers as `uint64`)
- `root.html`: options error now includes the invalid value for clarity

## Why is this change needed?

Nested object and array fields were silently skipped during validation — invalid nested values produced no errors.

## How to test

Tested via `presidium-configurable-frontmatter-default-test-module`:
- `make frontmatter-test` — schema assertions pass
- `make validate-content-validation` — 5 assertions pass (invalid nested pattern, missing required nested field, invalid array item option, happy-case has no spurious errors)

## Screenshots/Video (optional)