### PR TITLE
feat: PRSDM-10470: restrict taxonomy_term_lookup to single-select by default

### DIFF
--- a/data/schemas/frontmatter/types.yaml
+++ b/data/schemas/frontmatter/types.yaml
@@ -184,3 +184,4 @@ taxonomy_term_lookup:
   field: ""                           # [Optional] - Nested field name to extract from data objects
   pattern: ""                         # [Optional] - Not recommended as the input will be limited to the fixed options
   display_rows: 1                     # [Optional] - Not recommend as the input will be single line
+  multi_select: false                 # [Optional] - TODO: PRSDM-10548 - When FE supports multi-select, set to true to allow array values

--- a/layouts/_default/single.html
+++ b/layouts/_default/single.html
@@ -39,21 +39,21 @@ EXAMPLE: territories autocomplete field
 {{ end }}
 
 {{ define "section" }}
-{{- if not .Site.Params.schemaGenerationMode -}}
-{{/* Frontmatter Validation */}}
-{{- partial "frontmatter/validate.html" . -}}
-{{- $validation := .Scratch.Get "frontmatter_validation" -}}
-{{- if not $validation.valid -}}
-  {{- range $error := $validation.errors -}}
-    {{- warnf "[Frontmatter Validation] %s: %s" $.File.Path $error -}}
-  {{- end -}}
-{{- end -}}
-<section data-section="{{ strings.TrimPrefix "/" $.Parent.Path }}">
-{{ block "content" . }}
-    {{ partial "page/single" . }}
-{{ end }}
-</section>
-{{- end -}}
+    {{- if not .Site.Params.schemaGenerationMode -}}
+        {{/* Frontmatter Validation */}}
+        {{- partial "frontmatter/validate.html" . -}}
+        {{- $validation := .Scratch.Get "frontmatter_validation" -}}
+        {{- if not $validation.valid -}}
+            {{- range $error := $validation.errors -}}
+                {{- warnf "[Frontmatter Validation] %s: %s" $.File.Path $error -}}
+            {{- end -}}
+        {{- end -}}
+        <section data-section="{{ strings.TrimPrefix "/" $.Parent.Path }}">
+            {{ block "content" . }}
+                {{ partial "page/single" . }}
+            {{ end }}
+        </section>
+    {{- end -}}
 {{ end }}
 
 {{ define "footer" }}

--- a/layouts/partials/frontmatter/validators/types/taxonomy_term_lookup.html
+++ b/layouts/partials/frontmatter/validators/types/taxonomy_term_lookup.html
@@ -1,5 +1,6 @@
 {{/* Taxonomy Term Lookup Validator - validates taxonomy term values */}}
-{{/* Accepts either string (single value) or array (multiple values) */}}
+{{/* Accepts only a single string value. */}}
+{{/* TODO: PRSDM-10548 - When FE supports multi-select, check multi_select: true and allow array values */}}
 {{/* Assumes: value exists (root validator already checked required/null) */}}
 
 {{- $value := .value -}}
@@ -8,28 +9,25 @@
 {{- $ctx := .context -}}
 {{- $errors := slice -}}
 
-{{/* Type check: must be string or array */}}
+{{/* multi_select defaults to false — single value only until PRSDM-10548 is implemented */}}
+{{/* TODO: PRSDM-10548 - use $multiSelect to conditionally allow array values when FE supports multi-select */}}
+{{- $multiSelect := $rules.multi_select | default false -}}
+
+{{/* Type check: must be a single string (arrays not supported until PRSDM-10548) */}}
 {{- $valueType := printf "%T" $value -}}
 {{- $isString := eq $valueType "string" -}}
 {{- $isArray := hasPrefix $valueType "[]" -}}
 
-{{- if not (or $isString $isArray) -}}
-  {{- $errors = $errors | append (printf "%s must be a string or array" $fieldName) -}}
+{{- if $isArray -}}
+  {{/* TODO: PRSDM-10548 - when multi_select: true and FE supports it, allow array values here */}}
+  {{- $errors = $errors | append (printf "%s must be a single value (multi-select is not yet supported)" $fieldName) -}}
+{{- else if not $isString -}}
+  {{- $errors = $errors | append (printf "%s must be a string" $fieldName) -}}
 {{- else -}}
-  {{/* Normalize to array for validation */}}
-  {{- $values := slice -}}
-  {{- if $isString -}}
-    {{- $values = slice $value -}}
-  {{- else -}}
-    {{- $values = $value -}}
-  {{- end -}}
-
   {{/* Validate against options if provided */}}
   {{- if $rules.options -}}
-    {{- range $val := $values -}}
-      {{- if not (in $rules.options $val) -}}
-        {{- $errors = $errors | append (printf "%s contains invalid value: %s" $fieldName $val) -}}
-      {{- end -}}
+    {{- if not (in $rules.options $value) -}}
+      {{- $errors = $errors | append (printf "%s contains invalid value: %s" $fieldName $value) -}}
     {{- end -}}
   {{- end -}}
 {{- end -}}

--- a/layouts/partials/frontmatter/validators/types/taxonomy_term_lookup.html
+++ b/layouts/partials/frontmatter/validators/types/taxonomy_term_lookup.html
@@ -12,6 +12,9 @@
 {{/* multi_select defaults to false — single value only until PRSDM-10548 is implemented */}}
 {{/* TODO: PRSDM-10548 - use $multiSelect to conditionally allow array values when FE supports multi-select */}}
 {{- $multiSelect := $rules.multi_select | default false -}}
+{{- if $multiSelect -}}
+  {{- $errors = $errors | append (printf "%s is configured with multi_select: true, but multi-select is not yet supported" $fieldName) -}}
+{{- end -}}
 
 {{/* Type check: must be a single string (arrays not supported until PRSDM-10548) */}}
 {{- $valueType := printf "%T" $value -}}


### PR DESCRIPTION
<!-- Keep descriptions under 200 words. -->

[PRSDM-10470](https://spandigital.atlassian.net/browse/PRSDM-10470)

## What does this PR do?

- Adds `multi_select: boolean` (optional, default `false`) to the `taxonomy_term_lookup` type definition in `types.yaml`
- Rewrites the `taxonomy_term_lookup` validator to reject array values with the error "must be a single value (multi-select is not yet supported)"
- Fixes indentation in `layouts/_default/single.html` `section` block to match `header`/`footer` blocks (cosmetic)
- TODO PRSDM-10548 comments mark all future multi-select extension points

## Why is this change needed?

The front-end only supports a single value for `taxonomy_term_lookup` fields. The `multi_select` field is added as future-proofing for when PRSDM-10548 (FE multi-select support) lands.

## How to test

1. Check out the test module branch `PRSDM-10470-modify-taxonomy-term-lookup-fields-to-default-to-single-select`
2. Run `make validate-content-validation` — all 6 assertions should pass, including the new taxonomy_term_lookup multi-value rejection test

## Screenshots/Video (optional)