### PR TITLE
fix: PRSDM-10607: validate frontmatter on list pages (_index.md)

### DIFF
--- a/layouts/_default/list.html
+++ b/layouts/_default/list.html
@@ -41,6 +41,22 @@ EXAMPLE: territories autocomplete field
 
 {{ define "content" }}
     {{- if not .Site.Params.schemaGenerationMode -}}
+        {{/* Frontmatter Validation — only for real files, not Hugo virtual pages (e.g. taxonomy/category pages) */}}
+        {{- if $.File -}}
+            {{- partial "frontmatter/validate.html" . -}}
+            {{- $validation := .Scratch.Get "frontmatter_validation" -}}
+            {{- if not $validation.valid -}}
+                {{- $namespace := .Site.Params.data.namespace | default "presidium" -}}
+                {{- $schemaLocation := printf "data/%s/frontmatter-schema.yaml" $namespace -}}
+                {{- errorf "=====================================================================================================================================" -}}
+                {{- errorf "[Frontmatter Validation] Errors in the frontmatter of one or more articles are logged below." -}}
+                {{- errorf "[Frontmatter Validation] Review article frontmatter against the frontmatter schema located at %s." $schemaLocation -}}
+                {{- errorf "=====================================================================================================================================" -}}
+                {{- range $error := $validation.errors -}}
+                    {{- errorf "[Frontmatter Validation] %s: %s" $.File.Path $error -}}
+                {{- end -}}
+            {{- end -}}
+        {{- end -}}
         {{ partial "page/list" . }}
     {{- end -}}
 {{ end }}


### PR DESCRIPTION
<!-- Keep descriptions under 200 words. -->

[PRSDM-10607](https://spandigital.atlassian.net/browse/PRSDM-10607)

## What does this PR do?

Adds frontmatter validation to `layouts/_default/list.html` so that `_index.md` list pages are validated during a Hugo build. Previously only `single.html` called `validate.html`, meaning all `_index.md` files were silently skipped.

The validation block is guarded by `$.File` to skip Hugo virtual pages (taxonomy and category pages where `$.File` is `nil`).

## Why is this change needed?

Frontmatter errors on list pages were not caught at build time, creating a silent gap in validation coverage.

## How to test

1. Check out the branch and point a test module at `v0.15.2-configurable-frontmatter-22`.
2. Run `make frontmatter-test` then `make validate-content-validation`.
3. Confirm all 28 assertions pass, including: `Required field absent on _index.md (list page) triggers validation error`.

## Screenshots/Video (optional)