### PR TITLE
fix: PRSDM-10844: exclude draft sections and their articles from the searchmap

### DIFF
--- a/layouts/partials/searchmap/item.html
+++ b/layouts/partials/searchmap/item.html
@@ -32,16 +32,14 @@
     {{ $summary := (index (split .Content "</p>") 0) | plainify | htmlUnescape }}
     {{ if not .Params.draft }}
         {{ $items = $items | append (dict "id" .File.Path "title" .Title "slug" $slug "url" $link "section" ($section | default "") "category" ($category | default "") "tags" ($tags | default slice) "roles" (slice (.Params.Roles | default "All Roles")) "scope" $scope "author" (.Params.Author | default "None") "content" .Plain "originalContent" .RawContent "updated" .Lastmod "summary" $summary  )}}
-    {{ end }}
-    {{ else }}
-    {{ warnf "[searchmap] Skipping page with nil .File: Title=%q, Permalink=%q" .Title .Permalink }}
-    {{ end }}
-    {{ range .Data.Pages }}
-        {{ if not .Params.draft }}
+        {{ range .Data.Pages }}
             {{ range (partial "searchmap/item" (dict "Page" . "Level" $childLevel "Section" $section "Category" $category ) ) }}
               {{ $items = $items | append . }}
             {{ end }}
         {{ end }}
+    {{ end }}
+    {{ else }}
+    {{ warnf "[searchmap] Skipping page with nil .File: Title=%q, Permalink=%q" .Title .Permalink }}
     {{ end }}
 {{ end }}
 {{ return $items }}

--- a/layouts/partials/searchmap/item.html
+++ b/layouts/partials/searchmap/item.html
@@ -30,13 +30,17 @@
     {{ end }}
     {{ $tags := apply .Params.tags "cast.ToString" "."}}
     {{ $summary := (index (split .Content "</p>") 0) | plainify | htmlUnescape }}
-    {{ $items = $items | append (dict "id" .File.Path "title" .Title "slug" $slug "url" $link "section" ($section | default "") "category" ($category | default "") "tags" ($tags | default slice) "roles" (slice (.Params.Roles | default "All Roles")) "scope" $scope "author" (.Params.Author | default "None") "content" .Plain "originalContent" .RawContent "updated" .Lastmod "summary" $summary  )}}
+    {{ if not .Params.draft }}
+        {{ $items = $items | append (dict "id" .File.Path "title" .Title "slug" $slug "url" $link "section" ($section | default "") "category" ($category | default "") "tags" ($tags | default slice) "roles" (slice (.Params.Roles | default "All Roles")) "scope" $scope "author" (.Params.Author | default "None") "content" .Plain "originalContent" .RawContent "updated" .Lastmod "summary" $summary  )}}
+    {{ end }}
     {{ else }}
     {{ warnf "[searchmap] Skipping page with nil .File: Title=%q, Permalink=%q" .Title .Permalink }}
     {{ end }}
     {{ range .Data.Pages }}
-        {{ range (partial "searchmap/item" (dict "Page" . "Level" $childLevel "Section" $section "Category" $category ) ) }}
-          {{ $items = $items | append . }}
+        {{ if not .Params.draft }}
+            {{ range (partial "searchmap/item" (dict "Page" . "Level" $childLevel "Section" $section "Category" $category ) ) }}
+              {{ $items = $items | append . }}
+            {{ end }}
         {{ end }}
     {{ end }}
 {{ end }}


### PR DESCRIPTION
PRSDM-10844 (https://spandigital.atlassian.net/browse/PRSDM-10844)

# What does this PR do?                                                                                                                                                     

Excludes draft sections and their articles from the searchmap. Two guards added to `layouts/partials/searchmap/item.html`:                                                  
                                                                                                                                                                            
1. A section or article with `draft: true` in its frontmatter is not added to $items                                                                                        
2. When recursing into child pages, draft sections are skipped entirely.  This means all articles nested within a draft section are also excluded.
                                                                                                                                                                            
# Why is this change needed?                                                                                                                                                
                                                                                                                                                                            
When a section's `_index.md` is marked `draft: true`, Hugo does not render a permalink for that section. The searchmap partial was still recursing into draft sections and building article URLs using .Parent.RelPermalink, which returns empty string for unrendered pages. This produced bare fragment URLs (e.g. #setup instead of /docs/module/recipes/versioning/#setup) that were stored incorrectly in the database and caused downstream panics in the MCP server.                                      
                                                                                                                                                                            
**The desired behaviour is**: a draft section means everything inside it is draft and should not appear in the searchmap.                                                     
                                                                                                                                                                            
# How to test                                                                                                                                                                                                                                                                                                                                        
1. Modify go.mod to use `github.com/spandigital/presidium-layouts-base v0.16.0-fix-to-test-for-prsdm-10844-2` because it's not released yet.
1. Add `draft: true` to a section's _index.md in a test module                                                                                                              
2. Build the Hugo site and inspect `searchmap.json` in the `public` folder of the module                                                                                                                         
3. Confirm neither the section nor any of its child articles appear in the searchmap                                                                                      
4. Load the site into Presidium and verify no bare fragment URLs are stored for those articles