### PR TITLE
feat: PRSDM-11023 Improve sidebar chevron loading

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -32,3 +32,7 @@
 ## 2026-05-21
 ### Fix
 - Resolve duplicate URLs in searchmap.json. Additive only - kind: "branch" | "leaf". @christopherbrunsdon https://spandigital.atlassian.net/browse/PRSDM-9079
+
+## 2026-06-03
+### Feature
+- Replace Bootstrap glyphicon chevron/info/external icons with inline Lucide SVGs. @kelvinmanley https://spandigital.atlassian.net/browse/PRSDM-11023

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -9,6 +9,9 @@
     <meta name="viewport" content="width=device-width, initial-scale=1.0">
     {{ hugo.Generator }}
     <link rel="icon" href="{{ .Site.Params.favicon | absURL }}" type="image/x-icon">
+    <!-- Preload the enterprise logos -->
+    <link rel="preload" as="image" href="/assets/images/logo.svg" fetchpriority="high">
+    <link rel="preload" as="image" href="/assets/images/logo-small.svg" fetchpriority="high">
     {{ $basePath := $.Site.Params.basePath  | default "/" }}
     {{ $style := resources.Get "presidium.scss" | css.Sass | resources.Minify | resources.Fingerprint }}
     <link rel="stylesheet" href="{{ $style.RelPermalink }}">

--- a/layouts/partials/navigation/nav-item-external.html
+++ b/layouts/partials/navigation/nav-item-external.html
@@ -1,7 +1,7 @@
 <li class="menu-row">
     <div class="link level-1">
         {{ $newTab := .Params.externalUrl.newTab | default true }}
-        <a class="level-1" href="{{ .Params.externalUrl.href }}" target="{{ if $newTab }}_blank{{ end}}">
+        <a class="level-1" href="{{ .Params.externalUrl.href }}"{{ if $newTab }} target="_blank" rel="noopener"{{ end }}>
             <div class="menu-expander">
                 <svg class="external-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>
             </div>

--- a/layouts/partials/navigation/nav-item-external.html
+++ b/layouts/partials/navigation/nav-item-external.html
@@ -3,7 +3,7 @@
         {{ $newTab := .Params.externalUrl.newTab | default true }}
         <a class="level-1" href="{{ .Params.externalUrl.href }}" target="{{ if $newTab }}_blank{{ end}}">
             <div class="menu-expander">
-                <span class="glyphicon glyphicon-new-window"></span>
+                <svg class="external-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="M15 3h6v6"/><path d="M10 14 21 3"/><path d="M18 13v6a2 2 0 0 1-2 2H5a2 2 0 0 1-2-2V8a2 2 0 0 1 2-2h6"/></svg>
             </div>
             <div class="menu-title">
                 {{ .Name }}

--- a/layouts/partials/navigation/nav-item.html
+++ b/layouts/partials/navigation/nav-item.html
@@ -59,7 +59,7 @@
         <a class="level-{{ .Level }} {{ if eq .Index 0 }}first-child{{end}}" data-slug="{{ $slug }}" data-target="#{{$uid}}" data-id="{{ $articleId }}" href="{{ $articleLink }}">
             {{ if $hasChildren }}
                 <div class="menu-expander" aria-controls="{{$uid}}" aria-expanded="{{ if $isOpen }}true{{ else }}false{{ end }}">
-                    <span class="glyphicon {{ if $isOpen }}glyphicon-chevron-down{{ else }}glyphicon-chevron-right{{ end }} glyphicon-toggle"></span>
+                    <svg class="menu-expander-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><path d="m9 18 6-6-6-6"/></svg>
                 </div>
             {{ end }}
             <div class="menu-title">

--- a/layouts/partials/page/info.html
+++ b/layouts/partials/page/info.html
@@ -1,3 +1,3 @@
 <div class="well" id="no-content-warning">
-    <span class="glyphicon glyphicon-info-sign"> </span> No articles match the selected filter.
+    <svg class="info-icon" xmlns="http://www.w3.org/2000/svg" width="16" height="16" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><circle cx="12" cy="12" r="10"/><path d="M12 16v-4"/><path d="M12 8h.01"/></svg> No articles match the selected filter.
 </div>

--- a/layouts/partials/page/script.html
+++ b/layouts/partials/page/script.html
@@ -39,9 +39,6 @@
         $ul.removeClass('in active');
     }
 
-    const $trigger = $menu.find('div.menu-expander > .glyphicon').first();
-    $trigger.toggleClass('glyphicon-chevron-down', isOpen)
-            .toggleClass('glyphicon-chevron-right', !isOpen);
     $menu.find('div.menu-expander').first().attr('aria-expanded', isOpen ? 'true' : 'false');
   };
 


### PR DESCRIPTION
## Description
The chevrons which were using glyphicon font was replaced with inline SVGs (presidium-layouts-base) and the glyphicons and their styling were removed (presidium-styling-base). This speeds up the chevron being displayed as the font loading time is not applicable anymore. It also resolves an issue that was occurring when the font didn't load and had to rely on a fallback.

Also added preloading and prioritisation for Enterprise logos which improves their loading performance.

Related PR (presidium-styling-base): https://github.com/SPANDigital/presidium-styling-base/pull/103

## Issue
- [ ] :clipboard: [JIRA_TICKET_URL](https://spandigital.atlassian.net/browse/PRSDM-11023)

## Screenshots

https://github.com/user-attachments/assets/57dfb18d-0f8f-4c99-b237-dd88e94d15c8



## PR Readiness Checks
- [ ] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
- [ ] You have performed a self-review of your changes via the GitHub UI
- [ ] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
- [ ] New code adheres to the following quality standards:
  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
