### PR TITLE
feat: PRSDM-10924 upgrade themes to hugo v0.161.0

### DIFF
--- a/.github/pull_request_template.md
+++ b/.github/pull_request_template.md
@@ -1,16 +1,19 @@
-## Description
+<!-- Keep descriptions under 200 words. -->
 
-## Issue
-- [ ] :clipboard: JIRA_TICKET_URL
+JIRA_TICKET_URL
 
-## Screenshots
+## What does this PR do?
 
-## PR Readiness Checks
-- [ ] Your PR title conforms to conventional commits `<type>: <jira-ticket-num><title>`, for example: `fix: PRSDM-123 issue with login` with a maximum of 100 characters
-- [ ] You have performed a self-review of your changes via the GitHub UI
-- [ ] Comments were added to new code that can not explain itself (see [reference 1](https://bpoplauschi.github.io/2021/01/20/Clean-Code-Comments-by-Uncle-Bob-part-2.html) and [reference 2](https://blog.cleancoder.com/uncle-bob/2017/02/23/NecessaryComments.html))
-- [ ] New code adheres to the following quality standards:
-  - Function Length ([see reference](https://martinfowler.com/bliki/FunctionLength.html))
-  - Meaningful Names ([see reference](https://learning.oreilly.com/library/view/clean-code-a/9780136083238/chapter02.xhtml))
-  - DRY ([see reference](https://java-design-patterns.com/principles/#keep-things-dry))
-  - YAGNI ([see reference](https://java-design-patterns.com/principles/#yagni))
+## Why is this change needed?
+
+## How to test
+
+```sh
+# Test this PR
+bin/pr-test --services=<PR_NUM> --pat=<pat> --env=PRESIDIUM_ADMIN_USERNAMES=name.surname@spandigital.com
+
+# Cross-repo example (combine as needed)
+bin/pr-test --services=<PR_NUM> --js=<PR_NUM> --content=<PR_NUM> --pat=<pat> --env=PRESIDIUM_ADMIN_USERNAMES=name.surname@spandigital.com
+```
+
+## Screenshots/Video (optional)

--- a/config.yml
+++ b/config.yml
@@ -59,13 +59,7 @@ outputs:
   section:
     - HTML
     - Embed
-permalinks:
-  - pattern: /:sectionslugs/
-    target:
-      kind: section
-  - pattern: /:sectionslugs/:slug/
-    target:
-      kind: page
+
 params:
   _merge: shallow
   data:
@@ -82,3 +76,10 @@ params:
   enterprise-header-logo: images/default-enterprise-header-logo.png # this logo is used in the enterprise header across all docsets in the deployment.
   enterprise-header-logo-mobile: images/default-enterprise-header-logo-mobile.png # this logo is used in the enterprise header across all docsets in the deployment for mobile devices.
 
+permalinks:
+  - pattern: /:sectionslugs/
+    target:
+      kind: section
+  - pattern: /:sectionslugs/:slug/
+    target:
+      kind: page

--- a/config.yml
+++ b/config.yml
@@ -75,8 +75,6 @@ params:
     min: "0.161.0"
     max: "0.163.0"
     extended: true
-  attributes:
-    website: 2.15.0
   # not yet implemented
   docset-logo: images/logo.png # recommend minimum size of 250px x 250px. Is used on the landing page.
   left-nav-logo: images/logo.png # if the left nav logo is different from the main logo, specify it here.

--- a/config.yml
+++ b/config.yml
@@ -59,14 +59,21 @@ outputs:
   section:
     - HTML
     - Embed
+permalinks:
+  - pattern: /:sectionslugs/
+    target:
+      kind: section
+  - pattern: /:sectionslugs/:slug/
+    target:
+      kind: page
 params:
   _merge: shallow
   data:
-    namespace: "presidium"  # Data directory namespace for generated files (schema, etc.)
+    namespace: "presidium" # Data directory namespace for generated files (schema, etc.)
   hugoVersion:
     enabled: true
-    min: "0.156.0"
-    max: "0.161.0"
+    min: "0.161.0"
+    max: "0.163.0"
     extended: true
   attributes:
     website: 2.15.0


### PR DESCRIPTION
<!-- Keep descriptions under 200 words. -->
Upgrading Presidium Themes to be compatible with the new permalinks patterns introduced in Hugo v0.161.0

[PRSDM-10924](https://spandigital.atlassian.net/browse/PRSDM-10924)

## What does this PR do?
Lets us use the compact permalink patterns wildcards instead of the verbose permalinks pattern definition which required a separate definition for every top level section in the `content/` dir.

## Why is this change needed?
There was no way to maintain a unified permalinks pattern config in our themes until the new permalinks pattern wildcards feature was introduced.
Which meant every module required it's own manual config. 
So this has now been fixed for centalized management/config.

## How to test

Pull the branch to your localhost.

### 1. Setup Theme in Docs Module
Add this line to your docs module `go.mod` file.
```shell
replace github.com/spandigital/presidium-layouts-base => /path/to/your/presidium-layouts-base
```

### 2. Refresh the docs module
```shell
make refresh
```

### 3. Serve the docs module and navigate:
```shell
make serve-b
```

Open [localhost:7070](http://localhost:7070)
