### PR TITLE
feat: added hugo related skills

### DIFF
--- a/.claude/skills/hugo-templates/SKILL.md
+++ b/.claude/skills/hugo-templates/SKILL.md
@@ -1,0 +1,663 @@
+---
+name: hugo-templates
+description: Use when designing, debugging, or refactoring Hugo layouts, partials, lookup rules, render hooks, and asset pipelines at an expert level.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [hugo, templates, go-templates, partials, render-hooks, assets, lookup-order]
+    related_skills: [hugo, plan, requesting-code-review]
+---
+
+# Hugo templates, layouts, and rendering
+
+## Overview
+
+Use this skill when the task is specifically about Hugo's template system rather than Hugo installation or basic site setup.
+
+This skill covers how Hugo chooses templates, how context and Go template syntax behave, how to structure layouts and partials, how to use render hooks and the resource pipeline, and how to debug template-level problems without guessing.
+
+Prefer Hugo's official docs as source of truth for evolving behavior:
+
+- `https://gohugo.io/templates/`
+- `https://gohugo.io/templates/lookup-order/`
+- `https://gohugo.io/templates/types/`
+- `https://gohugo.io/functions/`
+- `https://gohugo.io/render-hooks/`
+
+Important details confirmed from the current docs and local Hugo v0.161.1:
+
+- Hugo selects templates from most specific to least specific.
+- Lookup is interleaved across the project and theme layout directories.
+- `type` and `layout` in front matter can target a different template.
+- `layouts/page.html` works for regular pages, while `single.html` is a fallback.
+- `baseof.html` + `block`/`define` is the core composition pattern.
+- Partials live under `layouts/_partials/`.
+- `partial` can return rendered HTML or any data type if the partial uses `return`.
+- `partialCached` caches output and accepts variant keys.
+- Render hooks live under `layouts/_markup/`.
+- Asset pipelines via `resources.Get`, `minify`, and `fingerprint` work naturally inside templates.
+- `hugo --templateMetrics --templateMetricsHints` emits per-template timing data.
+
+## When to Use
+
+- Build or refactor Hugo layouts for pages, sections, home, taxonomy, and terms
+- Diagnose why Hugo picked the wrong template
+- Create reusable partials with explicit context passing
+- Convert duplicated markup into `baseof.html`, `block`, `define`, and partials
+- Work with `.Site`, `.Page`, `.Params`, page collections, `where`, `sort`, `group`, and `range`
+- Implement render hooks for links, images, headings, code blocks, tables, or blockquotes
+- Build CSS/JS/image asset pipelines with Hugo resources
+- Debug scope issues involving `.` and `$`
+- Tune or validate expensive partials with `partialCached`
+- Create section-specific or type-specific template overrides
+
+Do not use this skill for:
+
+- Initial Hugo installation only
+- Generic Markdown authoring with no template work
+- Non-Hugo Go templates in unrelated tools
+- JS framework hydration patterns unless they are embedded in a Hugo template workflow
+
+## Mental model: how Hugo renders a page
+
+For any request or build target, think in this order:
+
+1. What page kind is this?
+   - `home`
+   - `page`
+   - `section`
+   - `taxonomy`
+   - `term`
+
+2. What makes it more specific?
+   - content type
+   - section
+   - language
+   - output format
+   - front matter `type`
+   - front matter `layout`
+
+3. Which template file wins?
+   - Hugo searches from most specific to least specific.
+   - It interleaves project and theme layouts, choosing the most specific match found in either.
+
+4. Does a base template apply?
+   - `baseof.html` provides the shared shell.
+   - the selected template fills named `block`s via `define`.
+
+5. Does the selected template call partials, render hooks, or resources?
+   - partials are ordinary subtemplates
+   - render hooks affect Markdown-to-HTML rendering
+   - resource pipelines generate processed assets
+
+If you keep those five steps straight, most Hugo template bugs become obvious.
+
+## Template file layout
+
+The modern high-signal files to reach for first are:
+
+```text
+layouts/
+  baseof.html
+  home.html
+  page.html
+  section.html
+  taxonomy.html
+  term.html
+  _partials/
+  _markup/
+```
+
+Important fallback behavior from the docs:
+
+- `page.html` is the specific template for regular content pages.
+- `single.html` is a fallback for regular pages when `page.html` does not exist.
+- List kinds fall back toward list-style templates such as `_default/list.html`.
+
+Practical guidance:
+
+- Prefer `home.html`, `page.html`, `section.html`, `taxonomy.html`, and `term.html` for clarity.
+- Only fall back to `_default/single.html` and `_default/list.html` when you intentionally want generic shared behavior.
+- Add section-specific or type-specific overrides only when there is a real divergence in presentation.
+
+## Template lookup order in practice
+
+Key current rules from the docs:
+
+- Hugo uses the most specific matching template.
+- Templates may live in the project's layout directory or a theme's layout directory.
+- Hugo interleaves project and theme lookups.
+- You cannot change the lookup order itself.
+- You can steer selection with front matter such as `type` and `layout`.
+
+Use these rules when debugging:
+
+1. Determine the page kind.
+2. Determine the page's content type and section.
+3. Check whether front matter sets `layout` or `type`.
+4. Inspect project `layouts/` before blaming the theme.
+5. Remember that a more specific template beats a generic one even if both exist.
+
+A reliable override strategy:
+
+- Put broad defaults in `layouts/page.html` or `layouts/section.html`.
+- Put targeted overrides in paths like `layouts/posts/page.html` when a specific section needs its own rendering.
+- Use front matter `layout = 'landing'` only when the content author should explicitly opt into a special template.
+
+## Auditing whether a theme param is actually used
+
+When a user asks whether a Hugo theme parameter is used, do not stop at exact symbol matches.
+
+Use this audit sequence:
+
+1. Search for exact references first:
+   - `.Site.Params.foo`
+   - `site.Params.foo`
+   - nested forms such as `.Site.Params.attributes.website`
+2. If exact references are absent, search for generic iteration over parent maps:
+   - `range .Site.Params.attributes`
+   - `isset .Site.Params`
+   - `index .Site.Params ...`
+   - merges or dict construction from params
+3. Trace any matching partial into its call sites.
+   - A parameter may be consumed indirectly inside a partial and emitted into HTML attributes, JSON, or script data.
+4. Distinguish between:
+   - direct logical use
+   - indirect generic use
+   - unused declaration
+
+Example pattern:
+
+```go-html-template
+{{ range $key, $value := .Site.Params.attributes }}
+  {{ $attrs = (printf "data-%s=\"%s\" %s" $key $value $attrs) | safeHTMLAttr }}
+{{ end }}
+```
+
+If a theme then includes that partial in `baseof.html`, every entry under `params.attributes` is effectively used even when no key such as `website` is referenced by name.
+
+## Base templates and block composition
+
+This is the primary composition pattern for maintainable Hugo sites.
+
+Base template:
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <title>{{ .Title }}</title>
+  </head>
+  <body>
+    <header>{{ partial "nav.html" . }}</header>
+    <main>{{ block "main" . }}{{ end }}</main>
+  </body>
+</html>
+```
+
+Page or section template:
+
+```html
+{{ define "main" }}
+  <h1>{{ .Title }}</h1>
+  {{ .Content }}
+{{ end }}
+```
+
+Best practices:
+
+- Keep `baseof.html` structural: head, shell, header, footer, slots.
+- Put page-specific logic inside `define` blocks, not in the base template.
+- Do not overload `baseof.html` with section-specific branching when separate templates would be clearer.
+- Use partials for shared fragments, not for every tiny one-liner.
+
+## Context, dot, and variables
+
+The single most common Hugo mistake is losing track of context.
+
+Rules:
+
+- `.` means the current context.
+- At the top of a page template, `.` is typically a `Page`.
+- Inside `range`, `with`, and some partials, `.` changes.
+- `$` points to the root context originally passed into the current template.
+
+Example:
+
+```go-html-template
+{{ range .Site.RegularPages }}
+  <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+  <span>Current page title: {{ $.Title }}</span>
+{{ end }}
+```
+
+Use this discipline:
+
+- Capture important objects up front:
+
+```go-html-template
+{{ $page := . }}
+{{ $pages := where site.RegularPages "Section" "posts" }}
+```
+
+- When passing multiple values to a partial, use `dict`.
+- When the partial needs the original page, pass it explicitly rather than assuming the dot will still be correct.
+
+Safe partial call pattern:
+
+```go-html-template
+{{ partial "card.html" (dict "page" . "class" "featured") }}
+```
+
+Then inside the partial:
+
+```go-html-template
+{{ $p := .page }}
+<article class="{{ .class }}">
+  <a href="{{ $p.RelPermalink }}">{{ $p.LinkTitle }}</a>
+</article>
+```
+
+## Page kinds and the right collections
+
+Use the collection that matches the page kind.
+
+Common patterns:
+
+### Home page
+
+```go-html-template
+{{ range site.RegularPages }}
+  <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+{{ end }}
+```
+
+### Section page
+
+```go-html-template
+{{ range .Pages }}
+  <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+{{ end }}
+```
+
+### Taxonomy page
+
+```go-html-template
+{{ range .Data.Terms.ByCount }}
+  <a href="{{ .Page.RelPermalink }}">{{ .Page.LinkTitle }}</a> ({{ .Count }})
+{{ end }}
+```
+
+### Term page
+
+```go-html-template
+{{ range .Pages }}
+  <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+{{ end }}
+```
+
+Practical rule:
+
+- Use `site.RegularPages` when you want a site-wide content collection.
+- Use `.Pages` when you want children of the current list-like page.
+- Use `.Data.Terms` only in taxonomy contexts.
+
+## Filtering, sorting, and grouping pages
+
+Reach for page collections before custom logic.
+
+Common patterns:
+
+```go-html-template
+{{ $posts := where site.RegularPages "Section" "posts" }}
+{{ $featured := where $posts "Params.featured" true }}
+{{ $sorted := sort $posts "Date" "desc" }}
+{{ range first 5 $sorted }}
+  <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+{{ end }}
+```
+
+Guidelines:
+
+- Filter first, then sort, then limit.
+- Avoid repeating the same expensive pipeline in many templates.
+- If reused often, compute once in a partial or assign to a variable.
+- If the computation is expensive and invariant for many pages, consider `partialCached`.
+
+## Partials: include, return values, and caching
+
+### `partial`
+
+Use `partial` for reusable template fragments.
+
+Key doc behavior:
+
+- `partial` optionally accepts context.
+- If the partial contains `return`, it returns that value.
+- Without `return`, it returns rendered HTML.
+
+HTML partial:
+
+```go-html-template
+{{ partial "breadcrumbs.html" . }}
+```
+
+Data-returning partial:
+
+```go-html-template
+{{ $card := partial "card-data.html" . }}
+<a href="{{ $card.link }}">{{ $card.title }}</a>
+```
+
+With partial implementation:
+
+```go-html-template
+{{ return (dict "title" .Title "link" .RelPermalink) }}
+```
+
+Use data-returning partials when you want shared derivation logic without coupling it to markup.
+
+### `partialCached`
+
+Use `partialCached` only when the output is genuinely reusable.
+
+Important doc behavior:
+
+- It caches the rendered result.
+- It accepts one or more variant keys.
+- Variant keys matter whenever output depends on page, language, theme mode, or another dimension.
+
+Pattern:
+
+```go-html-template
+{{ partialCached "styles.html" . .Site.Language.Lang }}
+```
+
+Rules of thumb:
+
+- If the partial output is globally identical, no variant key may be needed.
+- If output depends on language, section, color mode, output format, or page params, include those as variants.
+- Wrong variant keys create subtle cross-page bugs.
+- Do not use `partialCached` as a reflex; prove there is a repeated expensive partial first.
+
+## Render hooks
+
+Render hooks override Markdown rendering and belong in `layouts/_markup/`.
+
+Common files:
+
+```text
+layouts/_markup/render-link.html
+layouts/_markup/render-image.html
+layouts/_markup/render-heading.html
+layouts/_markup/render-codeblock.html
+```
+
+Use render hooks when the source content is Markdown but the output HTML needs policy or structure changes.
+
+Examples:
+
+- add attributes to outbound links
+- wrap images in `figure`
+- add heading anchors
+- customize code block chrome
+- adjust table or blockquote markup
+
+A minimal link render hook:
+
+```html
+<a href="{{ .Destination | safeURL }}" data-hook="link"{{ with .Title }} title="{{ . }}"{{ end }}>{{ .Text | safeHTML }}</a>
+```
+
+Important boundary:
+
+- Render hooks affect Markdown rendering.
+- They do not automatically change arbitrary HTML emitted by shortcodes, partials, or hard-coded layouts.
+
+## Resource pipelines for CSS, JS, and generated assets
+
+Hugo's resource pipeline is a template-level superpower.
+
+Typical CSS pattern:
+
+```go-html-template
+{{ with resources.Get "css/main.css" }}
+  {{ $css := . | minify | fingerprint }}
+  <link rel="stylesheet" href="{{ $css.RelPermalink }}" integrity="{{ $css.Data.Integrity }}">
+{{ end }}
+```
+
+Useful resource functions confirmed in the docs:
+
+- `resources.Get`
+- `resources.GetMatch`
+- `resources.Match`
+- `resources.FromString`
+- `resources.ExecuteAsTemplate`
+- `resources.Minify`
+- `resources.Fingerprint`
+- `resources.PostProcess`
+- `resources.GetRemote`
+
+Guidance:
+
+- Use `assets/` for pipeline-managed resources.
+- Use `static/` for files that should pass through unchanged.
+- Fingerprint production assets that need cache-busting and integrity metadata.
+- Use `resources.ExecuteAsTemplate` when an asset itself must be templated from site data.
+
+## Choosing between templates, partials, shortcodes, and render hooks
+
+Use the right abstraction:
+
+- Template (`home.html`, `page.html`, etc.): choose the full page structure
+- Partial: reusable site chrome or reusable derivation logic
+- Shortcode: author-invoked component inside Markdown content
+- Render hook: automatic transformation of Markdown-generated HTML
+
+Good decision rule:
+
+- If editors explicitly place it in content, use a shortcode.
+- If every Markdown link or image should change, use a render hook.
+- If it is shared layout chrome, use a partial.
+- If it defines the page shell or page-kind rendering, use a template.
+
+## Section-specific and custom layout strategies
+
+Prefer stable defaults plus narrow overrides.
+
+Examples:
+
+- generic article pages in `layouts/page.html`
+- blog section override in `layouts/posts/page.html`
+- custom landing layout selected via front matter `layout = 'landing'`
+
+Avoid these anti-patterns:
+
+- one giant template with many section `if eq` branches
+- front matter layouts for everything
+- duplicating near-identical markup across many section templates
+
+## Debugging workflow
+
+When Hugo templates misbehave, do this in order.
+
+### 1. Verify the render path
+
+Run a build and read the warnings:
+
+```bash
+hugo
+```
+
+If you suspect dev-server behavior differences:
+
+```bash
+hugo server -D --disableFastRender
+```
+
+### 2. Inspect template timing
+
+Use template metrics to find slow templates or partials:
+
+```bash
+hugo --templateMetrics --templateMetricsHints
+```
+
+This was verified locally and emits a table with cumulative duration, average duration, cache potential, cached count, and template name.
+
+### 3. Check the selected template by reasoning from kind and specificity
+
+Ask:
+
+- Is this `home`, `page`, `section`, `taxonomy`, or `term`?
+- Is there a more specific section or type template overshadowing the generic one?
+- Is front matter setting `layout` or `type`?
+- Is the theme providing a template I forgot about?
+
+### 4. Check context loss
+
+If values vanish inside a `range` or partial, suspect dot changes first.
+
+Typical fix:
+
+```go-html-template
+{{ $root := . }}
+{{ range .Pages }}
+  {{ partial "card.html" (dict "root" $root "page" .) }}
+{{ end }}
+```
+
+### 5. Reduce to the smallest reproducer
+
+If lookup order is confusing, temporarily create the minimum files needed:
+
+- `baseof.html`
+- one target template
+- one content file
+
+Then add specificity one step at a time.
+
+## Common Pitfalls
+
+1. Confusing `.` with `$`.
+   - Inside `range`, `.` often becomes the current element.
+   - Use `$` for the root context or pass values explicitly.
+
+2. Using a partial without passing the data it needs.
+   - Partials do not magically inherit every variable you intended.
+   - Pass a dict with named fields.
+
+3. Caching the wrong thing with `partialCached`.
+   - If output varies by language, page, or section, include variant keys.
+   - Otherwise one page can leak cached HTML into another.
+
+4. Debugging the wrong template file.
+   - Hugo may be using a more specific template than the one you are editing.
+   - Start with kind, type, section, layout, and theme overrides.
+
+5. Using `static/` instead of `assets/` for pipeline-managed files.
+   - `resources.Get` works with assets, not arbitrary static files.
+
+6. Expecting render hooks to affect manually-written HTML.
+   - Render hooks only intercept Markdown-rendered elements.
+
+7. Overusing front matter layouts.
+   - `layout` is powerful, but if every page needs it, the template hierarchy is probably wrong.
+
+8. Duplicating markup instead of using `baseof.html` and partials.
+   - Duplication makes template drift inevitable.
+
+9. Mixing content concerns into layout selection.
+   - Use front matter for content metadata.
+   - Use templates and partials for presentation.
+
+10. Ignoring build warnings for missing template kinds.
+   - Warnings like missing `section`, `taxonomy`, or `term` templates explain broken pages immediately.
+
+11. Treating “no exact grep hit” as proof that a param is unused.
+   - Theme params are often consumed through generic map iteration or helper partials.
+   - Audit both direct references and indirect use through partials before declaring a parameter dead.
+
+## One-shot recipes
+
+### Build a clean page/home/section skeleton
+
+1. Create:
+
+```text
+layouts/baseof.html
+layouts/home.html
+layouts/page.html
+layouts/section.html
+```
+
+2. Put shell markup in `baseof.html`.
+3. Put page-kind-specific content inside `define "main"` blocks.
+4. Build with `hugo` and inspect warnings.
+
+### Add a reusable component with explicit inputs
+
+1. Create `layouts/_partials/<name>.html`
+2. Call it with `dict`
+3. Keep presentation in the partial and data derivation in named variables
+4. If it only computes data, use `return`
+
+### Add custom Markdown link behavior
+
+1. Create `layouts/_markup/render-link.html`
+2. Use `.Destination`, `.Text`, and `.Title`
+3. Build a page containing Markdown links
+4. Inspect generated HTML, not just template source
+
+### Add fingerprinted CSS
+
+1. Put CSS under `assets/css/`
+2. In a head partial, call `resources.Get | minify | fingerprint`
+3. Include the resulting `RelPermalink` and integrity hash
+4. Build and confirm hashed files appear in output
+
+## Verified local patterns
+
+These patterns were exercised successfully with local Hugo v0.161.1:
+
+- `baseof.html` + `home.html`, `section.html`, and `page.html`
+- section-specific override via `layouts/posts/page.html`
+- `partial "..."` with `dict` input
+- partial `return` to produce a dict rather than HTML
+- `partialCached` with a language variant key
+- Markdown link customization via `layouts/_markup/render-link.html`
+- CSS processing with `resources.Get`, `minify`, and `fingerprint`
+- timing output from `hugo --templateMetrics --templateMetricsHints`
+
+See the linked reference file for compact copy-paste snippets.
+
+## Verification Checklist
+
+- [ ] Confirm the page kind before editing templates
+- [ ] Check for `type` and `layout` overrides in front matter
+- [ ] Prefer `home.html`, `page.html`, `section.html`, `taxonomy.html`, and `term.html` before generic fallbacks
+- [ ] Keep shell markup in `baseof.html`
+- [ ] Pass explicit context to partials, usually with `dict`
+- [ ] Use `$` or named variables when context changes under `range`/`with`
+- [ ] Use `partialCached` only with correct variant keys
+- [ ] Put resource-pipeline inputs in `assets/`, not `static/`
+- [ ] Put Markdown render hooks in `layouts/_markup/`
+- [ ] Run `hugo` and read warnings before assuming the template is correct
+- [ ] Use `hugo --templateMetrics --templateMetricsHints` when performance matters
+
+## References
+
+- Templates overview: https://gohugo.io/templates/
+- Introduction to templating: https://gohugo.io/templates/introduction/
+- Template lookup order: https://gohugo.io/templates/lookup-order/
+- Template types: https://gohugo.io/templates/types/
+- Partials: https://gohugo.io/functions/partials/
+- partial: https://gohugo.io/functions/partials/include/
+- partialCached: https://gohugo.io/functions/partials/includecached/
+- Go-template range: https://gohugo.io/functions/go-template/range/
+- Render hooks: https://gohugo.io/render-hooks/
+- Resources functions: https://gohugo.io/functions/resources/

--- a/.claude/skills/hugo-templates/references/quick-reference.md
+++ b/.claude/skills/hugo-templates/references/quick-reference.md
@@ -1,0 +1,159 @@
+# Hugo template quick reference
+
+## Minimal base + page kind files
+
+`layouts/baseof.html`
+
+```html
+<!doctype html>
+<html>
+  <head>
+    <title>{{ .Title }}</title>
+    {{ partialCached "styles.html" . .Site.Language.Lang }}
+  </head>
+  <body>
+    <header>{{ partial "nav.html" . }}</header>
+    <main>{{ block "main" . }}{{ end }}</main>
+  </body>
+</html>
+```
+
+`layouts/home.html`
+
+```html
+{{ define "main" }}
+  <h1>{{ .Site.Title }}</h1>
+  {{ range site.RegularPages }}
+    <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+  {{ end }}
+{{ end }}
+```
+
+`layouts/page.html`
+
+```html
+{{ define "main" }}
+  <article>
+    <h1>{{ .Title }}</h1>
+    {{ .Content }}
+  </article>
+{{ end }}
+```
+
+`layouts/section.html`
+
+```html
+{{ define "main" }}
+  <h1>{{ .Title }}</h1>
+  {{ range .Pages }}
+    <a href="{{ .RelPermalink }}">{{ .LinkTitle }}</a>
+  {{ end }}
+{{ end }}
+```
+
+## Pass explicit context to partials
+
+Caller:
+
+```go-html-template
+{{ partial "card.html" (dict "page" . "variant" "featured") }}
+```
+
+Partial:
+
+```go-html-template
+{{ $p := .page }}
+<article class="card card--{{ .variant }}">
+  <a href="{{ $p.RelPermalink }}">{{ $p.LinkTitle }}</a>
+</article>
+```
+
+## Return data from a partial
+
+Caller:
+
+```go-html-template
+{{ $meta := partial "page-meta.html" . }}
+<link rel="canonical" href="{{ $meta.canonical }}">
+```
+
+Partial:
+
+```go-html-template
+{{ return (dict
+  "canonical" .Permalink
+  "section" .Section
+  "kind" .Kind
+) }}
+```
+
+## Context safety inside range
+
+```go-html-template
+{{ $root := . }}
+{{ range .Site.RegularPages }}
+  <article>
+    <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+    <span>Rendered from: {{ $root.Title }}</span>
+  </article>
+{{ end }}
+```
+
+## Common page collection patterns
+
+Latest posts in a section:
+
+```go-html-template
+{{ $posts := where site.RegularPages "Section" "posts" }}
+{{ range first 5 (sort $posts "Date" "desc") }}
+  <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+{{ end }}
+```
+
+Featured content:
+
+```go-html-template
+{{ $featured := where site.RegularPages "Params.featured" true }}
+{{ range $featured }}
+  <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+{{ end }}
+```
+
+## Render hook for links
+
+`layouts/_markup/render-link.html`
+
+```html
+<a href="{{ .Destination | safeURL }}" data-hook="link"{{ with .Title }} title="{{ . }}"{{ end }}>{{ .Text | safeHTML }}</a>
+```
+
+## Fingerprinted CSS asset
+
+`layouts/_partials/styles.html`
+
+```go-html-template
+{{ with resources.Get "css/main.css" }}
+  {{ $css := . | minify | fingerprint }}
+  <link rel="stylesheet" href="{{ $css.RelPermalink }}" integrity="{{ $css.Data.Integrity }}">
+{{ end }}
+```
+
+## Section-specific override
+
+Use a more specific file when one section diverges:
+
+```text
+layouts/page.html
+layouts/posts/page.html
+```
+
+The `posts/page.html` template can override the generic page template for content in the `posts` section.
+
+## Template debugging commands
+
+```bash
+hugo
+hugo server -D --disableFastRender
+hugo --templateMetrics --templateMetricsHints
+hugo config
+```

--- a/.claude/skills/hugo/SKILL.md
+++ b/.claude/skills/hugo/SKILL.md
@@ -1,0 +1,532 @@
+---
+name: hugo
+description: Use when creating, developing, building, or troubleshooting websites with the Hugo static site generator.
+version: 1.0.0
+author: Hermes Agent
+license: MIT
+platforms: [linux, macos, windows]
+metadata:
+  hermes:
+    tags: [hugo, static-site-generator, ssg, markdown, themes, templates, deployment]
+    related_skills: [plan, requesting-code-review]
+---
+
+# Hugo static site generator
+
+## Overview
+
+Use this skill when the user wants to create, run, edit, build, or debug a site built with Hugo.
+
+Hugo is a static site generator with a CLI-centered workflow: create a project, add content under `content/`, render with templates and/or a theme, preview with `hugo server`, then build the deployable output with `hugo`.
+
+Prefer Hugo's own CLI and documentation over framework-specific folklore. The canonical docs are at `https://gohugo.io/`.
+
+Important current details confirmed from the docs and local CLI:
+
+- The quick start docs use `hugo new project <path>`.
+- `hugo new project` has aliases `project` and `site`, so `hugo new site <path>` also works.
+- `hugo new content <path>` creates new content, usually with `draft = true` in front matter.
+- `hugo server` is the development server and `hugo` / `hugo build` generates the static site.
+- On newer Hugo versions, `languageCode` is deprecated; prefer `locale` in config.
+- On this host, `hugo version` returned `hugo v0.161.1+extended+withdeploy`, so the extended edition is a good default recommendation.
+
+## When to Use
+
+- Create a new Hugo site or prototype
+- Add posts, pages, sections, menus, and front matter
+- Start a local dev server with drafts enabled
+- Install or wire up a Hugo theme
+- Build a production-ready static site into `public/` or another output directory
+- Troubleshoot missing layouts, drafts not appearing, broken base URLs, or module/theme issues
+- Inspect Hugo CLI capabilities such as `hugo mod`, `hugo list`, `hugo env`, and `hugo config`
+
+Do not use this skill for:
+
+- Next.js, Astro, Gatsby, Jekyll, or other non-Hugo site generators
+- CMS-specific editing workflows that do not involve the Hugo CLI
+- Generic Go module troubleshooting unrelated to a Hugo project
+
+## Installation and verification
+
+Prefer the extended edition unless the user explicitly says they only need the standard edition.
+
+Documented installation commands from gohugo.io:
+
+### macOS
+
+```bash
+brew install hugo
+```
+
+```bash
+sudo port install hugo
+```
+
+### Windows
+
+```powershell
+choco install hugo-extended
+```
+
+```powershell
+scoop install hugo-extended
+```
+
+```powershell
+winget install Hugo.Hugo.Extended
+```
+
+### Linux
+
+```bash
+brew install hugo
+```
+
+```bash
+sudo snap install hugo
+```
+
+Notes:
+
+- The Linux snap is strictly confined; according to the docs, sites should live in the user's home directory or on removable media.
+- Hugo quick start requires Hugo v0.158.0 or later and Git.
+
+Always verify with:
+
+```bash
+hugo version
+```
+
+Useful environment check:
+
+```bash
+hugo env
+```
+
+## Core CLI map
+
+These are the commands to reach for first:
+
+```text
+hugo                    Build the site
+hugo build              Explicit build command
+hugo server             Start the embedded dev server
+hugo new project PATH   Create a new project
+hugo new site PATH      Alias for new project
+hugo new content PATH   Create a new content file
+hugo list drafts        List draft content
+hugo config             Show effective project config
+hugo mod ...            Manage Hugo modules
+hugo version            Show version
+hugo env                Show version and environment info
+```
+
+## Standard workflow
+
+### 1. Create a project
+
+Use one of these:
+
+```bash
+hugo new project mysite
+```
+
+```bash
+hugo new site mysite
+```
+
+If you want YAML or JSON config instead of TOML:
+
+```bash
+hugo new project mysite --format yaml
+```
+
+Then enter the project:
+
+```bash
+cd mysite
+```
+
+### 2. Set minimal config
+
+Prefer `locale` over the deprecated `languageCode` key.
+
+Minimal `hugo.toml`:
+
+```toml
+baseURL = 'https://example.org/'
+locale = 'en-us'
+title = 'My Hugo Site'
+```
+
+If a theme is being used, add its config according to the theme docs. For a classic themes-directory setup this may look like:
+
+```toml
+theme = 'ananke'
+```
+
+### 3. Create content
+
+Create a post or page:
+
+```bash
+hugo new content posts/my-first-post.md
+```
+
+```bash
+hugo new content about.md
+```
+
+Typical generated front matter looks like this:
+
+```toml
++++
+title = 'My First Post'
+date = 2026-06-10T12:00:00Z
+draft = true
++++
+```
+
+Important behavior:
+
+- New content is often created as draft content.
+- `hugo` will not publish drafts by default.
+- For local preview, use `hugo server -D`.
+- For production builds, flip `draft = false` or remove the draft flag if appropriate.
+
+### 4. Preview locally
+
+Most common dev command:
+
+```bash
+hugo server -D
+```
+
+Useful variations:
+
+```bash
+hugo server --bind 0.0.0.0 --port 1313 -D
+```
+
+```bash
+hugo server --disableFastRender -D
+```
+
+Useful server facts confirmed from local CLI help:
+
+- Default bind address is `127.0.0.1`
+- Default port is `1313`
+- File watching is enabled by default
+- `-D` includes draft content
+- `--openBrowser` opens the site after startup
+- `--tlsAuto` can generate locally trusted certificates
+
+### 5. Build for deployment
+
+Default build:
+
+```bash
+hugo
+```
+
+Explicit build command:
+
+```bash
+hugo build
+```
+
+Choose an output directory:
+
+```bash
+hugo --destination public
+```
+
+Common production-ish build:
+
+```bash
+hugo --minify --gc
+```
+
+Draft and scheduling control:
+
+```bash
+hugo -D
+hugo -F
+hugo -E
+```
+
+These flags include draft, future, or expired content respectively. Use them intentionally; they are usually not what you want for production.
+
+## Themes: two common approaches
+
+### Approach A: classic themes directory
+
+The official quick start uses a Git submodule. Example:
+
+```bash
+git init
+git submodule add https://github.com/gohugo-ananke/ananke themes/ananke
+```
+
+Then set the theme in `hugo.toml`:
+
+```toml
+theme = 'ananke'
+```
+
+This is a good default when the theme's docs show a `themes/<name>` workflow.
+
+### Approach B: Hugo Modules
+
+When a theme uses Hugo Modules, initialize the project module first:
+
+```bash
+hugo mod init example.com/mysite
+```
+
+Then follow the theme's module import instructions.
+
+Useful maintenance commands:
+
+```bash
+hugo mod tidy
+hugo mod get
+hugo mod verify
+```
+
+Use module mode when the theme or component docs explicitly refer to `module.imports`, `go.mod`, or Hugo Modules.
+
+## Minimal no-theme site recipe
+
+Use this when the user wants the smallest reproducible Hugo setup without pulling a third-party theme.
+
+1. Create the project:
+
+```bash
+hugo new project demo
+cd demo
+```
+
+2. Create a minimal config:
+
+```toml
+baseURL = 'https://example.org/'
+locale = 'en-us'
+title = 'Demo Site'
+```
+
+3. Add minimal templates:
+
+`layouts/_default/baseof.html`
+
+```html
+<!doctype html>
+<html><body>{{ block "main" . }}{{ end }}</body></html>
+```
+
+`layouts/index.html`
+
+```html
+{{ define "main" }}
+<h1>{{ .Site.Title }}</h1>
+{{ range .Site.RegularPages }}
+  <a href="{{ .RelPermalink }}">{{ .Title }}</a>
+{{ end }}
+{{ end }}
+```
+
+`layouts/_default/single.html`
+
+```html
+{{ define "main" }}
+<article>
+  <h1>{{ .Title }}</h1>
+  {{ .Content }}
+</article>
+{{ end }}
+```
+
+4. Add content:
+
+```bash
+hugo new content posts/hello.md
+```
+
+Then edit the file so `draft = false` and add body content.
+
+5. Preview or build:
+
+```bash
+hugo server -D
+```
+
+```bash
+hugo --destination public
+```
+
+This exact pattern was validated locally with Hugo v0.161.1: project creation, content creation, module initialization, and a build to a custom destination all succeeded.
+
+## Permalinks and Hugo v0.161.0+
+
+When working on URL structure, distinguish between the permalink tokens and the permalink configuration form.
+
+Important rules:
+
+- `:sectionslugs` and `:sectionslug` are permalink tokens introduced before v0.161.0 (the docs mark them as new in v0.149.0).
+- The notable permalink feature added in v0.161.0 is the array form, where each entry uses a `pattern` and an optional `target` page matcher.
+- In array form, Hugo applies the first matching pattern.
+- Hugo still supports the older map form for section-based configuration.
+- The `url` front matter field overrides any matching permalink pattern.
+
+Array-form example:
+
+```yaml
+permalinks:
+  - pattern: /:sectionslugs
+    target:
+      kind: section
+  - pattern: /:sectionslugs/:slug
+    target:
+      kind: page
+```
+
+Audit workflow for permalink-heavy themes or sites:
+
+1. Read the source config and determine whether it uses map form or array form.
+2. Check for page-level `url:` overrides in front matter before blaming the permalink config.
+3. Run `hugo config` to inspect Hugo's effective configuration.
+4. If local Hugo is newer, note that `hugo config` may normalize older map-form rules into matcher-based `[[permalinks]]` output.
+5. Verify with a real build and inspect generated output paths under `public/` or a temporary `--destination`.
+
+Compatibility pitfall:
+
+- Do not migrate a site to explicit v0.161.0 array-form permalinks just because your local Hugo understands it.
+- First verify the build pipeline, CI image, or deployment environment supports Hugo >= v0.161.0.
+- If the pipeline is pinned below v0.161.0, keep the older source form until the pipeline is upgraded, even if a newer local Hugo normalizes it correctly.
+- In Hugo module/theme setups, all merged configs that define `permalinks` need to use the same data shape. If the site config uses array form but an imported module or theme config still uses map form, Hugo can fail during config merge with a panic like `interface conversion: interface {} is []interface {}, not hmaps.Params`.
+- When migrating permalinks in a module-based site, audit both the project config and every imported module/theme config that defines `permalinks`, including local `replace` overrides in `go.mod`.
+- After converting to array form, run both `hugo config` and a real `hugo` build. A successful edit to the site config alone is not enough proof if a module config still uses the old shape.
+
+See also `references/permalinks-v0161.md` for a compact audit note.
+
+## Recommended troubleshooting workflow
+
+When a Hugo site is broken, inspect in this order:
+
+1. Verify the toolchain:
+
+```bash
+hugo version
+hugo env
+```
+
+2. Inspect config:
+
+```bash
+hugo config
+```
+
+3. Preview with drafts and full warnings visible:
+
+```bash
+hugo server -D
+```
+
+4. Do a clean-ish production build:
+
+```bash
+hugo --gc --minify
+```
+
+5. Inspect content state:
+
+```bash
+hugo list drafts
+hugo list future
+hugo list expired
+```
+
+6. If modules are involved:
+
+```bash
+hugo mod tidy
+hugo mod verify
+```
+
+## Common Pitfalls
+
+1. Using `languageCode` in new configs.
+   - On newer Hugo versions this is deprecated.
+   - Prefer `locale = 'en-us'`.
+
+2. Expecting draft content to appear in a normal build.
+   - `hugo` excludes drafts by default.
+   - Use `hugo server -D` while writing, then set `draft = false` before release.
+
+3. Seeing `found no layout file` warnings.
+   - This means Hugo cannot find a template for a content kind such as `section`, `taxonomy`, `home`, or `single`.
+   - Fix by adding matching templates under `layouts/` or by installing/configuring a theme that provides them.
+
+4. Pulling in a theme without following that theme's installation style.
+   - Some themes expect the `themes/` directory.
+   - Others expect Hugo Modules and imports in config.
+   - Read the theme's docs before guessing.
+
+5. Broken absolute links after deploy.
+   - Usually `baseURL` is wrong for the final host.
+   - Set `baseURL` to the production URL before build, or use environment-specific config.
+
+6. Creating content from the wrong directory.
+   - `hugo new content ...` should be run from the project root unless you are explicitly using `--source`.
+
+7. Linux snap confusion.
+   - The snap package is confined.
+   - Keep the site in the home directory or use the snap permissions documented by Hugo.
+
+8. Assuming `hugo server` is the same as a production deployment.
+   - It is a development server with live reload.
+   - Always do a real `hugo` build before claiming the site is deploy-ready.
+
+## Output patterns for Hermes
+
+When helping a user with Hugo, prefer concise, command-first answers in this shape:
+
+```text
+Goal: <what we are doing>
+Project root: <path>
+Commands:
+1. <command>
+2. <command>
+Files to edit:
+- <path>
+Verification:
+- <what to check>
+```
+
+If you actually built or tested something, include:
+
+- the Hugo version used
+- the project path
+- the command that succeeded
+- the output directory or served URL
+- any warnings that still remain
+
+## Verification Checklist
+
+- [ ] `hugo version` runs successfully
+- [ ] The project was created with `hugo new project` or `hugo new site`
+- [ ] Config includes a correct `baseURL` and uses `locale` instead of deprecated `languageCode`
+- [ ] New content exists under `content/`
+- [ ] Draft behavior is understood: `hugo server -D` for preview, `draft = false` for production
+- [ ] Templates or a theme exist so the site can render without missing-layout surprises
+- [ ] `hugo` or `hugo build` completed successfully
+- [ ] The output directory (`public/` by default, or custom `--destination`) contains generated files
+- [ ] Any module-based theme setup was followed with `hugo mod tidy` / `hugo mod verify` as needed
+
+## References
+
+- Hugo home: https://gohugo.io/
+- Getting started: https://gohugo.io/getting-started/
+- Quick start: https://gohugo.io/getting-started/quick-start/
+- Installation: https://gohugo.io/installation/
+- CLI commands: https://gohugo.io/commands/

--- a/.claude/skills/hugo/references/permalinks-v0161.md
+++ b/.claude/skills/hugo/references/permalinks-v0161.md
@@ -1,0 +1,67 @@
+# Hugo permalink audit notes for v0.161.0+
+
+Use this note when reviewing a Hugo site's URL configuration after the permalink matcher changes introduced in v0.161.0.
+
+## What changed in v0.161.0
+
+Hugo added an array form for `permalinks`.
+
+Example:
+
+```yaml
+permalinks:
+  - pattern: /:sectionslugs/
+    target:
+      kind: section
+  - pattern: /:sectionslugs/:slug
+    target:
+      kind: page
+```
+
+Key behavior:
+
+- each entry requires `pattern`
+- `target` is optional
+- `target` accepts a page matcher
+- Hugo applies the first matching pattern
+
+## What did NOT change in v0.161.0
+
+The `:sectionslugs` token itself is older. Hugo docs mark `:sectionslugs` and `:sectionslug` as introduced in v0.149.0.
+
+So when someone says "new permalink features from v0.161.0", usually they mean matcher-based array configuration, not the token.
+
+## Safe review checklist
+
+1. Inspect source config.
+   - Is it old map form or new array form?
+2. Inspect front matter.
+   - `url:` overrides matching permalink config.
+   - `slug:` affects only the final path segment.
+3. Run `hugo config`.
+   - Newer Hugo may normalize old map form into `[[permalinks]]` matcher entries in effective config output.
+4. Build the site.
+   - Verify real output paths, not just config theory.
+5. Check aliases.
+   - Legacy numbered URLs may still be emitted on purpose via `aliases:`.
+
+## Practical interpretation rule
+
+If source config is old-style but `hugo config` shows the expected matcher-based effective output and the built paths are correct, the permalink behavior is correct even though the source has not been migrated.
+
+## Migration caution
+
+Do not rewrite a site into explicit array form until the build pipeline, CI image, or deployment environment supports Hugo >= v0.161.0.
+
+If local Hugo is newer than CI, local success is not enough.
+
+## Good audit conclusion template
+
+```text
+The permalink behavior is correct.
+The source config is still using the older map form.
+Hugo <current version> normalizes it into matcher-based effective config.
+Built output confirms the intended paths.
+Do not migrate to explicit array form until CI/build pipeline supports Hugo >= v0.161.0.
+Check front matter `url:` overrides before changing permalink config.
+```


### PR DESCRIPTION
<!-- Keep descriptions under 200 words. -->
Added some basic hugo & hugo template related skills to the themes

## What does this PR do?
Helps a user get Hugo related work done with more accuracy.

## Why is this change needed?
Hugo isn't the most well documented project.

## How to test

Just use claude code inside the project directory on your local machine.
