### PR TITLE
feat: PRSDM-11096 add evergreen field to searchmap output

### DIFF
--- a/layouts/partials/searchmap/item.html
+++ b/layouts/partials/searchmap/item.html
@@ -41,7 +41,7 @@
             {{ $tags := apply .Params.tags "cast.ToString" "."}}
             {{ $summary := (index (split .Content "</p>") 0) | plainify | htmlUnescape }}
             {{ $kind := cond .IsSection "branch" "leaf" }}
-            {{ $items = $items | append (dict "id" .File.Path "title" .Title "slug" $slug "url" $link "kind" $kind "section" ($section | default "") "category" ($category | default "") "tags" ($tags | default slice) "roles" (slice (.Params.Roles | default "All Roles")) "scope" $scope "author" (.Params.Author | default "None") "content" .Plain "originalContent" .RawContent "updated" .Lastmod "summary" $summary  )}}
+            {{ $items = $items | append (dict "id" .File.Path "title" .Title "slug" $slug "url" $link "kind" $kind "section" ($section | default "") "category" ($category | default "") "tags" ($tags | default slice) "roles" (slice (.Params.Roles | default "All Roles")) "scope" $scope "author" (.Params.Author | default "None") "content" .Plain "originalContent" .RawContent "updated" .Lastmod "summary" $summary "evergreen" (.Params.evergreen | default false)  )}}
         {{ end }}
     {{ end }}
     {{ range .Data.Pages }}


### PR DESCRIPTION
[PRSDM-11096](https://spandigital.atlassian.net/browse/PRSDM-11096)

## What does this PR do?

Adds the article-level `evergreen` frontmatter value to the searchmap JSON output. When an article has `evergreen: true` in its frontmatter, that value is now included in searchmap.json so downstream services can consume it.

## Why is this change needed?

The evergreen flag only existed at the project level. To display per-article freshness correctly (e.g., always showing max freshness for evergreen articles), individual articles need to declare themselves as evergreen via frontmatter, and that value must flow through the data pipeline starting from the Hugo build output.

## How to test

1. Add `evergreen: true` to any article's frontmatter
2. Build the Hugo site
3. Inspect `public/searchmap.json`, the article entry should include `"evergreen": true`
4. Articles without the frontmatter flag should have `"evergreen": false`

