### PR TITLE
fix: PRSDM-10689 Updated menu icon to SVG

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -40,3 +40,7 @@
 ## 2026-06-17
 ### Feature
 - Increase Presidium app load priority and de-prioritise Mermaid load priority. @kelvinmanley https://spandigital.atlassian.net/browse/PRSDM-11134
+
+## 2026-06-26
+### Fix
+- Updated menu icon to SVG. @kelvinmanley https://spandigital.atlassian.net/browse/PRSDM-10689

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -66,9 +66,7 @@
       <div class="toolbar-wrapper">
         <button class="toggle">
           <span class="sr-only">Toggle navigation</span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
-          <span class="icon-bar"></span>
+          <svg class="toggle-icon" xmlns="http://www.w3.org/2000/svg" width="24" height="24" viewBox="0 0 24 24" fill="none" stroke="currentColor" stroke-width="2" stroke-linecap="round" stroke-linejoin="round" aria-hidden="true"><line x1="4" x2="20" y1="12" y2="12"/><line x1="4" x2="20" y1="6" y2="6"/><line x1="4" x2="20" y1="18" y2="18"/></svg>
         </button>
         <div
           data-key="{{ $.Site.Params.enterprise_key }}"


### PR DESCRIPTION
<!-- Keep descriptions under 200 words. -->

[JIRA_TICKET_URL](https://spandigital.atlassian.net/browse/PRSDM-10689)

## What does this PR do?
Updates the menu icon to be an SVG

## Why is this change needed?
The old version execution was incorrect

## Related PR
https://github.com/SPANDigital/presidium-styling-base/pull/106

## How to test
Open module in mobile view and observe the menu icon

## Screenshots/Video (optional)

https://github.com/user-attachments/assets/7ac40030-2cd9-4447-89f8-6db4c2828eab

