### PR TITLE
feat: PRSDM-11048 perf cleanup

### DIFF
--- a/layouts/partials/page/analytics.html
+++ b/layouts/partials/page/analytics.html
@@ -1,3 +1,5 @@
+<link rel="preconnect" href="https://www.googletagmanager.com" crossorigin>
+<link rel="dns-prefetch" href="https://www.googletagmanager.com">
 <script async src="https://www.googletagmanager.com/gtag/js?id={{ $.Site.Params.analyticsToken }}"></script>
 <script>
     window.dataLayer = window.dataLayer || [];


### PR DESCRIPTION
<!-- Keep descriptions under 200 words. -->

- https://spandigital.atlassian.net/browse/PRSDM-11048


Is part of:

- https://github.com/SPANDigital/presidium-js-enterprise/pull/1459

- https://github.com/SPANDigital/presidium-styling-base/pull/107

- https://github.com/SPANDigital/presidium-layouts-base/pull/115

## What does this PR do?

## Why is this change needed?

**Problem:** `analytics.html` loads `gtag/js` with no `<link rel="preconnect">`, costing
80–350ms of avoidable connection setup.

## How to test

```sh
# Test this PR
bin/pr-test --js=1459 --pat=<pat> --env=PRESIDIUM_ADMIN_USERNAMES=name.surname@spandigital.com
```


## Screenshots/Video (optional)

<img width="3300" height="1126" alt="Monosnap Overview - Presidium Test Validation 2026-07-08 11-42-31" src="https://github.com/user-attachments/assets/f6a82390-4a66-4a66-96d8-ce5f897e5ad0" />
