### PR TITLE
feat: PRSDM-11171 emit frontmatter in searchmap articles

### DIFF
--- a/layouts/partials/searchmap/item.html
+++ b/layouts/partials/searchmap/item.html
@@ -41,7 +41,8 @@
             {{ $tags := apply .Params.tags "cast.ToString" "."}}
             {{ $summary := (index (split .Content "</p>") 0) | plainify | htmlUnescape }}
             {{ $kind := cond .IsSection "branch" "leaf" }}
-            {{ $items = $items | append (dict "id" .File.Path "title" .Title "slug" $slug "url" $link "kind" $kind "section" ($section | default "") "category" ($category | default "") "tags" ($tags | default slice) "roles" (slice (.Params.Roles | default "All Roles")) "scope" $scope "author" (.Params.Author | default "None") "content" .Plain "originalContent" .RawContent "updated" .Lastmod "summary" $summary "evergreen" (.Params.evergreen | default false)  )}}
+            {{ $frontmatter := merge .Params (dict "title" .Title) }}
+            {{ $items = $items | append (dict "id" .File.Path "title" .Title "slug" $slug "url" $link "kind" $kind "section" ($section | default "") "category" ($category | default "") "tags" ($tags | default slice) "roles" (slice (.Params.Roles | default "All Roles")) "scope" $scope "author" (.Params.Author | default "None") "content" .Plain "originalContent" .RawContent "updated" .Lastmod "summary" $summary "evergreen" (.Params.evergreen | default false) "frontmatter" $frontmatter )}}
         {{ end }}
     {{ end }}
     {{ range .Data.Pages }}

--- a/layouts/partials/searchmap/item.html
+++ b/layouts/partials/searchmap/item.html
@@ -41,7 +41,18 @@
             {{ $tags := apply .Params.tags "cast.ToString" "."}}
             {{ $summary := (index (split .Content "</p>") 0) | plainify | htmlUnescape }}
             {{ $kind := cond .IsSection "branch" "leaf" }}
-            {{ $frontmatter := merge .Params (dict "title" .Title) }}
+            {{/* Raw file frontmatter (exact keys and spelling, nothing Hugo-injected) —
+                 .Params is unusable here: Hugo lowercases keys and merges computed values. */}}
+            {{ $frontmatter := dict }}
+            {{ with .File.Filename }}
+                {{ $rawFile := readFile . }}
+                {{ $fmBlock := findRE `(?s)\A---\r?\n.*?\r?\n---(\r?\n|\z)` $rawFile 1 }}
+                {{ with $fmBlock }}
+                    {{ $yaml := replaceRE `(?s)\A---\r?\n` "" (index . 0) }}
+                    {{ $yaml = replaceRE `(?s)\r?\n---(\r?\n|\z)\z` "" $yaml }}
+                    {{ $frontmatter = $yaml | transform.Unmarshal }}
+                {{ end }}
+            {{ end }}
             {{ $items = $items | append (dict "id" .File.Path "title" .Title "slug" $slug "url" $link "kind" $kind "section" ($section | default "") "category" ($category | default "") "tags" ($tags | default slice) "roles" (slice (.Params.Roles | default "All Roles")) "scope" $scope "author" (.Params.Author | default "None") "content" .Plain "originalContent" .RawContent "updated" .Lastmod "summary" $summary "evergreen" (.Params.evergreen | default false) "frontmatter" $frontmatter )}}
         {{ end }}
     {{ end }}


### PR DESCRIPTION
[PRSDM-11171](https://spandigital.atlassian.net/browse/PRSDM-11171)

## What does this PR do?

Each searchmap article gains a `frontmatter` object containing the source file's frontmatter, parsed raw from the markdown file (`readFile` + `transform.Unmarshal`).

## Why is this change needed?

PRSDM-11171 moves frontmatter into the services DB using the searchmap as the transfer vehicle. The downstream consumer needs the blob to mirror the file **exactly** (same key spelling, same field set.)

That rules out `.Params`, the obvious implementation: Hugo lowercases all param keys, merges cascade values, and injects computed fields (`iscjklanguage`, `lastmod`, `draft`), none of which are editable file content. Reading the file and parsing the `---` block generically preserves everything as authored.

The content-builder strips this field before the searchmap is deployed, so it never reaches S3 or the search index (companion PR).

## How to test

Build any site against this branch (`replace` directive), then:
`jq '.[0].frontmatter' public/searchmap.json` — matches the file's frontmatter exactly; no `iscjklanguage`/injected keys.
