### PR TITLE
feat: lazy-load mermaid.js only on articles with mermaid diagrams

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -128,7 +128,7 @@
     </div>
 
     {{ partialCached "page/modal" 0 }}
-    {{ partialCached "page/script" . }}
+    {{ partialCached "page/script" . (.HasShortcode "diagram") }}
     {{ if $.Site.Params.analyticsToken }}
       {{ partialCached "analytics.html"  . }}
     {{ end }}

--- a/layouts/partials/page/script.html
+++ b/layouts/partials/page/script.html
@@ -1,4 +1,5 @@
 {{ $basePath := $.Site.Params.basePath  | default "/" }}
+{{ $hasMermaid := .HasShortcode "diagram" }}
 <script defer src="{{ path.Join $basePath "/presidium.js" }}"></script>
 {{ if $.Site.Params.enterprise_enabled }}
 <script defer src="{{ path.Join $basePath $.Site.Params.enterprise_script  }}"></script>
@@ -17,7 +18,25 @@
 
 <script defer src="{{ "assets/scripts/jquery.min.js" | absURL }}"></script>
 <script defer src="{{ "assets/scripts/bootstrap.min.js" | absURL }}"></script>
+{{ if $hasMermaid }}
 <script defer fetchpriority="low" src="{{ "assets/scripts/mermaid.js" | absURL }}"></script>
+<script type="module">
+  document.addEventListener('DOMContentLoaded', () => {
+    mermaid.initialize({
+        startOnLoad: true,
+        theme: 'base',
+        themeVariables: {
+            'primaryColor': '#00827E',
+            'primaryBorderColor': '#2C6764',
+            'secondaryColor': '#FFFFFF',
+            'lineColor': '#666',
+        },
+    });
+    // Explicitly initialize all Mermaid diagrams
+    mermaid.init(undefined, document.querySelectorAll('.mermaid'));
+  });
+</script>
+{{ end }}
 
 <script type="module">
   $('.toolbar-wrapper > button.toggle').on('click', (event) => {
@@ -101,21 +120,6 @@
 
   window.presidium?.tooltips?.load();
   window.presidium?.modal?.init();
-
-  document.addEventListener('DOMContentLoaded', () => {
-    mermaid.initialize({
-        startOnLoad: true,
-        theme: 'base',
-        themeVariables: {
-            'primaryColor': '#00827E',
-            'primaryBorderColor': '#2C6764',
-            'secondaryColor': '#FFFFFF',
-            'lineColor': '#666',
-        },
-    });
-    // Explicitly initialize all Mermaid diagrams
-    mermaid.init(undefined, document.querySelectorAll('.mermaid'));
-  });
 
   // Ensure nav-items fit within the viewport without overlapping the header
   document.addEventListener("DOMContentLoaded", function () {


### PR DESCRIPTION
[PRSDM-11046](https://spandigital.atlassian.net/browse/PRSDM-11046)

## What does this PR do?
Only injects the `mermaid.js` `<script>` tag (and its init call) on article pages that actually contain a mermaid diagram, using `.HasShortcode "diagram"`. Also adds that check as a cache-key variant on the `page/script` `partialCached` call, since without a variant Hugo renders that partial once and reuses the same output for every page.

## Why is this change needed?
Lighthouse audit (PRSDM-10721) found `mermaid.js` is 2.6 MiB and ships on every article page, with 92% reported unused. Gating it behind the presence of a mermaid diagram removes that cost from the majority of articles that don't use one.

## How to test

Verified locally with a throwaway Hugo site using this module as a theme: a page with a `{{< diagram >}}` shortcode still ships and initializes `mermaid.js` and renders its diagram, while a plain article has no `mermaid.js` script tag or init call in its output HTML.

## Screenshots

<img width="591" height="176" alt="Screenshot 2026-07-09 at 11 10 47 p m" src="https://github.com/user-attachments/assets/eb38073c-399c-4b5b-9ca4-2ced9a14b9d6" />

**Before:**

<img width="564" height="391" alt="Screenshot 2026-07-09 at 11 11 54 p m" src="https://github.com/user-attachments/assets/4384acf3-46c1-47fb-a098-51ef158a05f9" />

**After:**

<img width="557" height="387" alt="Screenshot 2026-07-09 at 11 12 33 p m" src="https://github.com/user-attachments/assets/9eeebffa-6b5c-4d06-a117-a8848ea5165c" />

<img width="565" height="194" alt="Screenshot 2026-07-09 at 11 12 56 p m" src="https://github.com/user-attachments/assets/50bd8a82-0956-40c0-80a8-2d700b2ff763" />

