### PR TITLE
feat: PRSDM-11352 Apply dark mode based on localstorage

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -44,3 +44,7 @@
 ## 2026-06-26
 ### Fix
 - Updated menu icon to SVG. @kelvinmanley https://spandigital.atlassian.net/browse/PRSDM-10689
+
+## 2026-07-28
+### Feature
+- Apply dark mode class on page load. @kelvinmanley https://spandigital.atlassian.net/browse/PRSDM-11352

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -134,4 +134,10 @@
     {{ end }}
 
 </body>
+<script>
+  const theme = localStorage.getItem('theme');
+  if (theme === 'dark') {
+    document.body.classList.add('dark');
+  }
+</script>
 </html>

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -14,6 +14,15 @@
     <link rel="preload" as="image" href="/assets/images/logo-small.svg" fetchpriority="high">
     {{ $basePath := $.Site.Params.basePath  | default "/" }}
     {{ $style := resources.Get "presidium.scss" | css.Sass | resources.Minify | resources.Fingerprint }}
+    <script>
+      try {
+        if (localStorage.getItem('theme') === 'dark') {
+          document.documentElement.classList.add('dark');
+        }
+      } catch (error) {
+        // localStorage may be unavailable, so skip restoring the theme preference.
+      }
+    </script>
     <link rel="stylesheet" href="{{ $style.RelPermalink }}">
     {{ if resources.Get "index.scss" }}
       {{ with resources.Get "index.scss" | css.Sass | resources.Minify | resources.Fingerprint }}
@@ -61,13 +70,6 @@
 </head>
 
 <body id="presidium" {{ partial "page/attributes" . }}>
-    <script>
-      try {
-        if (localStorage.getItem('theme') === 'dark') {
-          document.body.classList.add('dark');
-        }
-      } catch (e) {}
-    </script>
     {{ if $.Site.Params.enterprise_enabled }}
     {{ block "toolbar" . }}
       <div class="toolbar-wrapper">

--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -61,6 +61,13 @@
 </head>
 
 <body id="presidium" {{ partial "page/attributes" . }}>
+    <script>
+      try {
+        if (localStorage.getItem('theme') === 'dark') {
+          document.body.classList.add('dark');
+        }
+      } catch (e) {}
+    </script>
     {{ if $.Site.Params.enterprise_enabled }}
     {{ block "toolbar" . }}
       <div class="toolbar-wrapper">
@@ -134,10 +141,4 @@
     {{ end }}
 
 </body>
-<script>
-  const theme = localStorage.getItem('theme');
-  if (theme === 'dark') {
-    document.body.classList.add('dark');
-  }
-</script>
 </html>


### PR DESCRIPTION
<!-- Keep descriptions under 200 words. -->

[JIRA_TICKET_URL](https://spandigital.atlassian.net/browse/PRSDM-11352)

## What does this PR do?
Inline script added which runs early during page render to apply the user's saved dark-mode preference before the page paints. This prevent a flash of unstyled content (FOUC)

## Why is this change needed?
This change is required for the dark mode implementation

## Dependent PRs
presidium-layouts-base: https://github.com/SPANDigital/presidium-layouts-base/pull/121
presidium-js-enterprise: https://github.com/SPANDigital/presidium-js-enterprise/pull/1508

## How to test
1. Load up the dependent PRs for presidium-layouts-base and presidium-styling-base locally
2. Choose a module (e.g. presidium-docs-internal) and in the `go.mod` file point to your local base files, e.g:
```
module github.com/spandigital/span-handbook-docs

go 1.25

require (
	github.com/spandigital/presidium-layouts-base v0.16.0 // indirect
	github.com/spandigital/presidium-styling-base v0.8.0 // indirect
)
replace github.com/spandigital/presidium-layouts-base => path to your local layouts-base
replace github.com/spandigital/presidium-styling-base => path to your local styling-base

## Screenshots/Video (optional)

https://github.com/user-attachments/assets/bfb7755a-0514-4221-94dd-0eeb1bd7f76c

