### PR TITLE
fix: detect mermaid diagrams via the rendered DOM instead of page shortcodes

### DIFF
--- a/layouts/_default/baseof.html
+++ b/layouts/_default/baseof.html
@@ -137,7 +137,7 @@
     </div>
 
     {{ partialCached "page/modal" 0 }}
-    {{ partialCached "page/script" . (.HasShortcode "diagram") }}
+    {{ partialCached "page/script" . }}
     {{ if $.Site.Params.analyticsToken }}
       {{ partialCached "analytics.html"  . }}
     {{ end }}

--- a/layouts/partials/page/script.html
+++ b/layouts/partials/page/script.html
@@ -1,5 +1,4 @@
 {{ $basePath := $.Site.Params.basePath  | default "/" }}
-{{ $hasMermaid := .HasShortcode "diagram" }}
 <script defer src="{{ path.Join $basePath "/presidium.js" }}"></script>
 {{ if $.Site.Params.enterprise_enabled }}
 <script defer src="{{ path.Join $basePath $.Site.Params.enterprise_script  }}"></script>
@@ -18,25 +17,33 @@
 
 <script defer src="{{ "assets/scripts/jquery.min.js" | absURL }}"></script>
 <script defer src="{{ "assets/scripts/bootstrap.min.js" | absURL }}"></script>
-{{ if $hasMermaid }}
-<script defer fetchpriority="low" src="{{ "assets/scripts/mermaid.js" | absURL }}"></script>
 <script type="module">
   document.addEventListener('DOMContentLoaded', () => {
-    mermaid.initialize({
-        startOnLoad: true,
-        theme: 'base',
-        themeVariables: {
-            'primaryColor': '#00827E',
-            'primaryBorderColor': '#2C6764',
-            'secondaryColor': '#FFFFFF',
-            'lineColor': '#666',
-        },
-    });
-    // Explicitly initialize all Mermaid diagrams
-    mermaid.init(undefined, document.querySelectorAll('.mermaid'));
+    // Detect diagrams in the rendered DOM rather than this page's own source,
+    // since section pages recursively transclude descendant pages' content
+    // (see article/nested.html) and may show diagrams they don't themselves author.
+    if (!document.querySelector('.mermaid')) return;
+
+    const mermaidScript = document.createElement('script');
+    mermaidScript.src = '{{ "assets/scripts/mermaid.js" | absURL }}';
+    mermaidScript.setAttribute('fetchpriority', 'low');
+    mermaidScript.onload = () => {
+      mermaid.initialize({
+          startOnLoad: true,
+          theme: 'base',
+          themeVariables: {
+              'primaryColor': '#00827E',
+              'primaryBorderColor': '#2C6764',
+              'secondaryColor': '#FFFFFF',
+              'lineColor': '#666',
+          },
+      });
+      // Explicitly initialize all Mermaid diagrams
+      mermaid.init(undefined, document.querySelectorAll('.mermaid'));
+    };
+    document.head.appendChild(mermaidScript);
   });
 </script>
-{{ end }}
 
 <script type="module">
   $('.toolbar-wrapper > button.toggle').on('click', (event) => {


### PR DESCRIPTION
<!-- Keep descriptions under 200 words. -->

Related: https://spandigital.atlassian.net/browse/PRSDM-11046 (no separate ticket filed yet for this regression)

## What does this PR do?
Fixes a regression from the PRSDM-11046 mermaid.js lazy-load change: diagrams silently stopped rendering on any section/index page that recursively embeds a descendant page's diagram without itself using the `{{< diagram >}}` shortcode. Replaces the build-time `.HasShortcode "diagram"` check with a runtime check — an always-emitted script that waits for `DOMContentLoaded`, checks whether the rendered page actually contains a `.mermaid` element, and only then dynamically loads and initializes `mermaid.js`. Also drops the now-unnecessary `partialCached` cache-key variant in `baseof.html`.

## Why is this change needed?
`article/nested.html` recursively transcludes descendant pages' content into ancestor section pages (unbounded, via `includeNestedArticles`, which defaults to `true`). `.HasShortcode` only sees a page's own source, so any ancestor without its own diagram shortcode never loaded mermaid.js even when its rendered HTML contained a descendant's diagram. Confirmed on real content in both `span-handbook-docs` (`low-level-plan/`, `high-level-plan/`, `project-execution/`, `span-approach/`) and `bitfocus-ai-offering` (`process-flows/`, all 43 diagrams).

## How to test

```sh
# Test this PR
bin/pr-test --services=<PR_NUM> --pat=<pat> --env=PRESIDIUM_ADMIN_USERNAMES=name.surname@spandigital.com
```

Verified locally against both real modules via `go.mod replace`: pages without any `.mermaid` element in the rendered DOM still fetch zero bytes of `mermaid.js` (unchanged from PRSDM-11046), while previously-broken pages like `span-handbook-docs`'s `low-level-plan/` (9 diagrams) and `bitfocus-ai-offering`'s `process-flows/` (43 diagrams) now render every diagram correctly.

## Screenshots/Video (optional)
Before:

https://github.com/user-attachments/assets/4a07b083-fe58-432c-bd69-07a7cf6826c6





After:

https://github.com/user-attachments/assets/4f4b869e-57dc-4ed0-ae55-9a25ce82a7fa


