### PR TITLE
perf: cache closed navigation subtrees to cut full-site build time ~4x

### DIFF
--- a/layouts/partials/navigation/nav-item.html
+++ b/layouts/partials/navigation/nav-item.html
@@ -79,11 +79,11 @@
                 {{ $sortOrder := (partial "common/sortorder" (dict "SortByFilePath" $sortByFilePath)) }}
                 {{/* Sort by file prefix */}}
                 {{ range $index, $subMenu := (sort (after $offset $pages) "File.Path" $sortOrder) }}
-                    {{ partial "navigation/nav-item" (dict "NavPage" $subMenu "CurrentPage" $currentPage "Level" $childLevel "Index" $index "RootUrl" $rootUrl "SlugifyUrl" $slugifyUrl ) }}
+                    {{ if or ($subMenu.Eq $currentPage) ($subMenu.IsAncestor $currentPage) (eq $subMenu.Parent.RelPermalink $currentPage.RelPermalink) (eq $subMenu.RelPermalink $currentPage.RelPermalink) }}{{ partial "navigation/nav-item" (dict "NavPage" $subMenu "CurrentPage" $currentPage "Level" $childLevel "Index" $index "RootUrl" $rootUrl "SlugifyUrl" $slugifyUrl ) }}{{ else }}{{ partialCached "navigation/nav-item" (dict "NavPage" $subMenu "CurrentPage" (site.GetPage "/404" | default site.Home) "Level" $childLevel "Index" $index "RootUrl" $rootUrl "SlugifyUrl" $slugifyUrl ) $subMenu.RelPermalink }}{{ end }}
                 {{ end }}
             {{ else }}
                 {{ range $index, $subMenu := after $offset $pages }}
-                    {{ partial "navigation/nav-item" (dict "NavPage" $subMenu "CurrentPage" $currentPage "Level" $childLevel "Index" $index "RootUrl" $rootUrl "SlugifyUrl" $slugifyUrl ) }}
+                    {{ if or ($subMenu.Eq $currentPage) ($subMenu.IsAncestor $currentPage) (eq $subMenu.Parent.RelPermalink $currentPage.RelPermalink) (eq $subMenu.RelPermalink $currentPage.RelPermalink) }}{{ partial "navigation/nav-item" (dict "NavPage" $subMenu "CurrentPage" $currentPage "Level" $childLevel "Index" $index "RootUrl" $rootUrl "SlugifyUrl" $slugifyUrl ) }}{{ else }}{{ partialCached "navigation/nav-item" (dict "NavPage" $subMenu "CurrentPage" (site.GetPage "/404" | default site.Home) "Level" $childLevel "Index" $index "RootUrl" $rootUrl "SlugifyUrl" $slugifyUrl ) $subMenu.RelPermalink }}{{ end }}
                 {{ end }}
             {{ end }}
         </ul>

--- a/layouts/partials/navigation/root.html
+++ b/layouts/partials/navigation/root.html
@@ -19,9 +19,9 @@
           {{ if $menu.Params.externalUrl}} 
             {{ partial "navigation/nav-item-external" $menu }} 
           {{ else }}
-            {{ $identifier := anchorize $menu.Identifier }}
+            {{ $identifier := anchorize $menu.Identifier }}{{/* A section subtree's markup only depends on the current page when the current page lives inside it (open/active state); for every other page it renders fully closed and identical, so it is cached once per section. The 404 page is the stand-in current page for cached renders: its URL never matches a nav item, so nothing renders open or current. The RelPermalink equality check keeps subtrees fresh when the current page shares the subtree's URL (e.g. a section mounted at "/" while rendering home). */}}
             {{ with $.Site.GetPage $identifier }}
-              {{ partial "navigation/nav-item" (dict "NavPage" . "CurrentPage" $ "MenuName" $menu.Name "Level" 1 "Expanded" true "Collapsed" $menu.Params.Collapsed "RootUrl" $rootUrl "Show" false "SlugifyUrl" $slugifyUrl ) }}
+              {{ if or (.Eq $) (.IsAncestor $) (eq .RelPermalink $.RelPermalink) }}{{ partial "navigation/nav-item" (dict "NavPage" . "CurrentPage" $ "MenuName" $menu.Name "Level" 1 "Expanded" true "Collapsed" $menu.Params.Collapsed "RootUrl" $rootUrl "Show" false "SlugifyUrl" $slugifyUrl ) }}{{ else }}{{ partialCached "navigation/nav-item" (dict "NavPage" . "CurrentPage" (site.GetPage "/404" | default site.Home) "MenuName" $menu.Name "Level" 1 "Expanded" true "Collapsed" $menu.Params.Collapsed "RootUrl" $rootUrl "Show" false "SlugifyUrl" $slugifyUrl ) .RelPermalink }}{{ end }}
             {{ end }}
           {{ end }} 
         {{ end }} 


### PR DESCRIPTION
<!-- Keep descriptions under 200 words. -->

N/A

## What does this PR do?

Caches left-nav section subtrees with `partialCached` in `navigation/root.html` and `navigation/nav-item.html`. A subtree only renders fresh when the current page lives inside it (open/active state); everywhere else it renders fully closed and identical, so it is now rendered once and reused. Cached renders use the 404 page as the stand-in current page (its URL never matches a nav item), and RelPermalink guards keep subtrees mounted at "/" correct while rendering home.

## Why is this change needed?

The nav (~657 items) was re-rendered on every page. On the SPAN Handbook (659 articles) that was 436k `nav-item` executions, ~80% of build CPU. This change cuts a clean build from 5.3s to 1.28s (44s to 7.7s CPU) with byte-identical output, verified by a full `diff -r` of the built site against an unmodified baseline.

## How to test

Or locally: build any large Presidium site with a `replace` to this branch, once on `main` and once on this branch, and diff the two output directories (identical) and compare build times.

🤖 Generated with [Claude Code](https://claude.com/claude-code)